### PR TITLE
fix(workspace): write plan.md to correct issue directory location

### DIFF
--- a/src/workspace/create.rs
+++ b/src/workspace/create.rs
@@ -107,12 +107,15 @@ async fn create_plan_template(
 
 > **Note**: After completing this plan, save it using:
 > ```bash
-> centy add plan {display_number} --file plan.md
+> centy add plan {display_number} --file .centy/issues/{issue_id}/plan.md
 > ```
 "
     );
 
-    let plan_path = workspace_path.join("plan.md");
+    let plan_path = workspace_path
+        .join(".centy/issues")
+        .join(issue_id)
+        .join("plan.md");
     fs::write(&plan_path, plan_content).await?;
 
     Ok(())


### PR DESCRIPTION
## Summary
- Fixed bug where plan.md was created at workspace root instead of `.centy/issues/{issue_id}/plan.md`
- Updated template note to reference the correct file path

## Changes
- Modified `create_plan_template` function in `src/workspace/create.rs` to write plan.md to the correct issue directory
- Updated the template's "save it using" note to reference the correct path

## Issue
Fixes Issue #80 (67c95355-cd64-484d-8776-f19e4e2bbf3c)

## Test plan
- [x] All 231 unit tests pass
- [x] Clippy checks pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)