### PR TITLE
fix(planning): handle markdown-formatted planning note detection

### DIFF
--- a/src/issue/planning.rs
+++ b/src/issue/planning.rs
@@ -17,8 +17,15 @@ pub fn is_planning_status(status: &str) -> bool {
 }
 
 /// Check if issue content has the planning note
+/// Handles both original and markdown-formatted versions
 pub fn has_planning_note(content: &str) -> bool {
-    content.starts_with(PLANNING_NOTE) || content.contains(PLANNING_NOTE)
+    // Check for exact match first
+    if content.starts_with(PLANNING_NOTE) || content.contains(PLANNING_NOTE) {
+        return true;
+    }
+    // Check for formatted version (markdown formatter may add spaces/newlines)
+    // The distinctive marker is "> **Planning Mode**" or " > **Planning Mode**"
+    content.contains("> **Planning Mode**")
 }
 
 /// Add planning note to issue content (at the top)

--- a/src/utils/format.rs
+++ b/src/utils/format.rs
@@ -42,4 +42,23 @@ mod tests {
         // Should not have double newline
         assert!(!output.ends_with("\n\n"));
     }
+
+    #[test]
+    fn test_format_markdown_converts_ellipsis() {
+        // format_markdown converts ... to Unicode ellipsis …
+        let input = "The users API...";
+        let output = format_markdown(input);
+        assert!(output.contains("…"), "Should convert ... to …");
+    }
+
+    #[test]
+    fn test_format_markdown_preserves_blockquote_content() {
+        // Blockquotes may be reformatted but content should remain
+        let input = "> **Planning Mode**: Some text\n\n# Title\n";
+        let output = format_markdown(input);
+        assert!(
+            output.contains("> **Planning Mode**") || output.contains(" > **Planning Mode**"),
+            "Should preserve blockquote content"
+        );
+    }
 }

--- a/tests/template_test.rs
+++ b/tests/template_test.rs
@@ -240,7 +240,8 @@ type: "api-reference"
 
     assert!(doc_content.contains("type: \"api-reference\""));
     assert!(doc_content.contains("# API: Users Endpoint"));
-    assert!(doc_content.contains("The users API..."));
+    // Note: format_markdown converts ... to Unicode ellipsis …
+    assert!(doc_content.contains("The users API…"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Fixed planning note detection to handle markdown-formatted content
- Updated template test to expect Unicode ellipsis from format_markdown

The `format_markdown` function was transforming blockquotes in a way that broke the exact string matching for planning notes. Updated `has_planning_note` to also check for the `"> **Planning Mode**"` pattern.

## Test plan
- [x] All 459 tests pass
- [x] `test_planning_note_idempotent` now passes
- [x] `test_create_doc_with_explicit_template` now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)