### PR TITLE
feat(llm): add deepdive action for brainstorming questions

### DIFF
--- a/proto/centy.proto
+++ b/proto/centy.proto
@@ -1340,6 +1340,7 @@ enum LlmAction {
   LLM_ACTION_UNSPECIFIED = 0;
   LLM_ACTION_PLAN = 1;
   LLM_ACTION_IMPLEMENT = 2;
+  LLM_ACTION_DEEPDIVE = 3;
 }
 
 // Agent configuration (stored in config.local.json)

--- a/src/llm/agent.rs
+++ b/src/llm/agent.rs
@@ -73,6 +73,7 @@ pub async fn start_agent(
     let user_template = match action {
         LlmAction::Plan => agent.plan_template.as_deref(),
         LlmAction::Implement => agent.implement_template.as_deref(),
+        LlmAction::Deepdive => None, // Deepdive uses default prompt only
     };
     let prompt = prompt_builder
         .build_prompt(project_path, issue, action, user_template, priority_levels)

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2979,6 +2979,16 @@ impl CentyDaemon for CentyDaemonService {
                         keyboard_shortcut: "i".to_string(),
                     });
 
+                    actions.push(EntityAction {
+                        id: "mode:deepdive".to_string(),
+                        label: "Deep Dive".to_string(),
+                        category: ActionCategory::Mode as i32,
+                        enabled: true,
+                        disabled_reason: String::new(),
+                        destructive: false,
+                        keyboard_shortcut: "D".to_string(),
+                    });
+
                     // Status actions - contextual based on current status
                     for state in &allowed_states {
                         let is_current = entity_status.as_ref().map(|s| s == state).unwrap_or(false);


### PR DESCRIPTION
## Summary
- Add a new LLM action type "deepdive" that generates comprehensive brainstorming questions for an issue
- The agent produces a q&a.md file with questions organized by category (Requirements, Technical, Risks) with placeholder answers for the user to fill in

## Changes
- Add `LLM_ACTION_DEEPDIVE` to proto enum
- Add `Deepdive` variant to `LlmAction` in prompt.rs  
- Add `DEEPDIVE_ACTION_PROMPT` template
- Add `mode:deepdive` EntityAction with keyboard shortcut "D"

## Test plan
- [x] Build passes
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)