### PR TITLE
feat(workspace): require user config for auto status change on IDE open

### DIFF
--- a/proto/centy.proto
+++ b/proto/centy.proto
@@ -617,7 +617,7 @@ message CustomFieldDefinition {
 
 message LlmConfig {
   bool auto_close_on_complete = 1;    // Auto-close issues when marked complete by LLM
-  bool update_status_on_start = 2;    // Update status to in-progress when LLM starts work
+  optional bool update_status_on_start = 2;    // Update status to in-progress when LLM starts work (null = prompt user)
   bool allow_direct_edits = 3;        // Allow LLM to directly edit issue files
   WorkspaceMode default_workspace_mode = 4;  // Default workspace mode for agent operations
 }
@@ -1474,6 +1474,7 @@ message OpenInTempVscodeResponse {
   uint32 display_number = 5;            // Issue display number
   string expires_at = 6;                // ISO timestamp when workspace expires
   bool vscode_opened = 7;               // Whether VS Code was successfully opened
+  bool requires_status_config = 8;      // True if user must configure update_status_on_start setting
 }
 
 // Request to open an agent in a terminal
@@ -1494,6 +1495,7 @@ message OpenAgentInTerminalResponse {
   string agent_command = 6;             // The agent command that was executed
   bool terminal_opened = 7;             // Whether terminal was successfully opened
   string expires_at = 8;                // ISO timestamp (only for temp mode)
+  bool requires_status_config = 9;      // True if user must configure update_status_on_start setting
 }
 
 // A temporary workspace entry

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -57,9 +57,10 @@ pub struct LlmConfig {
     /// If true, LLM should auto-close issues after completing the work
     #[serde(default)]
     pub auto_close_on_complete: bool,
-    /// If true, LLM should update status to "in-progress" when starting work
-    #[serde(default)]
-    pub update_status_on_start: bool,
+    /// If true, LLM should update status to "in-progress" when starting work.
+    /// If None, the user must be prompted to configure this setting.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub update_status_on_start: Option<bool>,
     /// If true, LLM may directly edit metadata.json files. If false, use centy CLI
     #[serde(default)]
     pub allow_direct_edits: bool,

--- a/tests/server_test.rs
+++ b/tests/server_test.rs
@@ -376,9 +376,9 @@ fn test_config_hex_color_format() {
 fn test_llm_config_defaults() {
     let llm_config = InternalLlmConfig::default();
 
-    // Default values - all default to false via serde(default)
+    // Default values - bools default to false, Option<bool> defaults to None
     assert!(!llm_config.auto_close_on_complete);
-    assert!(!llm_config.update_status_on_start);
+    assert!(llm_config.update_status_on_start.is_none()); // Defaults to None so user must be prompted
     assert!(!llm_config.allow_direct_edits);
 }
 


### PR DESCRIPTION
## Summary
- When opening an issue with IDE, if `update_status_on_start` is not configured, return `requires_status_config: true` so client can prompt user
- Change `update_status_on_start` from `bool` to `optional bool`
- Add `requires_status_config` field to responses

## Test plan
- [x] All 256 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)