### PR TITLE
Remove global dead_code lint and address warnings (issue #109)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,8 +94,6 @@ cargo-husky = { version = "1", default-features = false, features = ["precommit-
 
 [lints.rust]
 unsafe_code = "forbid"
-# Allow dead code since many items are exported for library use
-dead_code = "allow"
 
 [lints.clippy]
 # Enable pedantic lints

--- a/src/common/org_sync.rs
+++ b/src/common/org_sync.rs
@@ -12,14 +12,8 @@ use crate::registry::{get_org_projects, RegistryError};
 /// Error types for org sync operations
 #[derive(Error, Debug)]
 pub enum OrgSyncError {
-    #[error("Project has no organization")]
-    NoOrganization,
-
     #[error("Registry error: {0}")]
     RegistryError(#[from] RegistryError),
-
-    #[error("Item not found: {0}")]
-    ItemNotFound(String),
 
     #[error("Sync failed: {0}")]
     SyncFailed(String),
@@ -76,12 +70,6 @@ pub struct OrgSyncResult {
 /// ```
 #[async_trait]
 pub trait OrgSyncable: Sized + Send + Sync {
-    /// The unique identifier for this item (e.g., UUID for issues, slug for docs)
-    fn item_id(&self) -> &str;
-
-    /// Whether this item is an organization-level item
-    fn is_org_item(&self) -> bool;
-
     /// The organization slug, if this is an org item
     fn org_slug(&self) -> Option<&str>;
 

--- a/src/features/crud.rs
+++ b/src/features/crud.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+//! Feature CRUD operations (WIP - not yet integrated)
 
 use crate::issue::{list_issues, Issue};
 use crate::manifest::{read_manifest, update_manifest_timestamp, write_manifest};

--- a/src/features/types.rs
+++ b/src/features/types.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+//! Feature types (WIP - not yet integrated)
 
 use serde::{Deserialize, Serialize};
 
@@ -36,7 +36,7 @@ pub struct MigrationFrontmatter {
 
 impl MigrationFrontmatter {
     /// Parse frontmatter from markdown content
-    #[must_use] 
+    #[allow(dead_code)] // Part of WIP features module
     pub fn parse(content: &str) -> Option<Self> {
         let lines: Vec<&str> = content.lines().collect();
 
@@ -53,7 +53,7 @@ impl MigrationFrontmatter {
     }
 
     /// Generate YAML frontmatter string
-    #[must_use] 
+    #[allow(dead_code)] // Part of WIP features module
     pub fn to_yaml(&self) -> String {
         serde_yaml::to_string(self).unwrap_or_default()
     }

--- a/src/issue/crud.rs
+++ b/src/issue/crud.rs
@@ -985,14 +985,6 @@ fn generate_issue_md(title: &str, description: &str) -> String {
 
 #[async_trait]
 impl OrgSyncable for Issue {
-    fn item_id(&self) -> &str {
-        &self.id
-    }
-
-    fn is_org_item(&self) -> bool {
-        self.metadata.is_org_issue
-    }
-
     fn org_slug(&self) -> Option<&str> {
         self.metadata.org_slug.as_deref()
     }

--- a/src/issue/id.rs
+++ b/src/issue/id.rs
@@ -30,17 +30,6 @@ pub fn generate_issue_id() -> String {
     Uuid::new_v4().to_string()
 }
 
-/// Get the short form of an issue ID (first 8 characters)
-/// Useful for display purposes
-#[must_use] 
-pub fn short_id(id: &str) -> &str {
-    if id.len() >= 8 {
-        &id[..8]
-    } else {
-        id
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -95,10 +84,4 @@ mod tests {
         assert_ne!(id, id2);
     }
 
-    #[test]
-    fn test_short_id() {
-        assert_eq!(short_id("a3f2b1c9-4d5e-6f7a-8b9c-0d1e2f3a4b5c"), "a3f2b1c9");
-        assert_eq!(short_id("0001"), "0001");
-        assert_eq!(short_id("abc"), "abc");
-    }
 }

--- a/src/issue/metadata.rs
+++ b/src/issue/metadata.rs
@@ -35,25 +35,6 @@ pub struct IssueMetadata {
 
 impl IssueMetadata {
     #[must_use]
-    pub fn new(
-        display_number: u32,
-        status: String,
-        priority: u32,
-        custom_fields: HashMap<String, serde_json::Value>,
-    ) -> Self {
-        Self {
-            common: CommonMetadata::new(display_number, status, priority, custom_fields),
-            compacted: false,
-            compacted_at: None,
-            draft: false,
-            deleted_at: None,
-            is_org_issue: false,
-            org_slug: None,
-            org_display_number: None,
-        }
-    }
-
-    #[must_use]
     pub fn new_draft(
         display_number: u32,
         status: String,
@@ -135,14 +116,14 @@ mod tests {
 
     #[test]
     fn test_serialize_priority_as_number() {
-        let metadata = IssueMetadata::new(1, "open".to_string(), 2, HashMap::new());
+        let metadata = IssueMetadata::new_draft(1, "open".to_string(), 2, HashMap::new(), false);
         let json = serde_json::to_string(&metadata).unwrap();
         assert!(json.contains(r#""priority":2"#));
     }
 
     #[test]
-    fn test_metadata_new() {
-        let metadata = IssueMetadata::new(1, "open".to_string(), 1, HashMap::new());
+    fn test_metadata_new_draft() {
+        let metadata = IssueMetadata::new_draft(1, "open".to_string(), 1, HashMap::new(), false);
         assert_eq!(metadata.common.display_number, 1);
         assert_eq!(metadata.common.status, "open");
         assert_eq!(metadata.common.priority, 1);
@@ -160,7 +141,7 @@ mod tests {
 
     #[test]
     fn test_serialize_display_number() {
-        let metadata = IssueMetadata::new(42, "open".to_string(), 1, HashMap::new());
+        let metadata = IssueMetadata::new_draft(42, "open".to_string(), 1, HashMap::new(), false);
         let json = serde_json::to_string(&metadata).unwrap();
         assert!(json.contains(r#""displayNumber":42"#));
     }
@@ -168,7 +149,7 @@ mod tests {
     #[test]
     fn test_flatten_produces_flat_json() {
         // Verify that #[serde(flatten)] produces flat JSON, not nested under "common"
-        let metadata = IssueMetadata::new(1, "open".to_string(), 2, HashMap::new());
+        let metadata = IssueMetadata::new_draft(1, "open".to_string(), 2, HashMap::new(), false);
         let json = serde_json::to_string(&metadata).unwrap();
         // Should NOT contain "common" as a key
         assert!(!json.contains(r#""common""#));

--- a/src/issue/org_registry.rs
+++ b/src/issue/org_registry.rs
@@ -137,19 +137,6 @@ pub async fn get_next_org_display_number(
     Ok(next)
 }
 
-/// Get the current (last used) org display number for an organization.
-///
-/// Returns 0 if no org issues have been created for this organization yet.
-pub async fn get_current_org_display_number(
-    org_slug: &str,
-) -> Result<u32, OrgIssueRegistryError> {
-    let registry = read_org_issue_registry().await?;
-
-    // The registry stores "next" number, so current is next - 1
-    let next = *registry.next_display_number.get(org_slug).unwrap_or(&1);
-    Ok(next.saturating_sub(1))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/issue/priority.rs
+++ b/src/issue/priority.rs
@@ -4,9 +4,6 @@ use thiserror::Error;
 pub enum PriorityError {
     #[error("Priority {0} is out of range. Valid values: 1 to {1}")]
     OutOfRange(u32, u32),
-
-    #[error("Unknown priority label: {0}")]
-    UnknownLabel(String),
 }
 
 /// Validate that priority is within the configured range

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub use migration::{
 pub use version::{compare_versions, daemon_version, SemVer, VersionComparison, VersionError};
 pub use llm::{
     spawn_agent, start_agent, get_effective_local_config, read_work_session, clear_work_session,
-    record_work_session, AgentConfig, AgentSpawnMode, AgentType, LocalLlmConfig, LlmAction, LlmError,
+    record_work_session, AgentConfig, AgentSpawnMode, AgentType, LocalLlmConfig, LlmAction,
     LlmWorkSession, PromptBuilder,
 };
 pub use user::{

--- a/src/link/storage.rs
+++ b/src/link/storage.rs
@@ -22,12 +22,6 @@ impl LinksFile {
         Self { links: Vec::new() }
     }
 
-    /// Create a links file with the given links
-    #[must_use]
-    pub fn with_links(links: Vec<Link>) -> Self {
-        Self { links }
-    }
-
     /// Add a link to this file
     pub fn add_link(&mut self, link: Link) {
         self.links.push(link);
@@ -56,14 +50,6 @@ impl LinksFile {
         self.links
             .iter()
             .any(|link| link.target_id == target_id && link.link_type == link_type)
-    }
-
-    /// Get all links of a specific type
-    pub fn links_of_type(&self, link_type: &str) -> Vec<&Link> {
-        self.links
-            .iter()
-            .filter(|link| link.link_type == link_type)
-            .collect()
     }
 }
 

--- a/src/llm/generate.rs
+++ b/src/llm/generate.rs
@@ -72,7 +72,6 @@ struct LlmTitleResponse {
 #[derive(Debug, Clone)]
 pub struct GeneratedTitle {
     pub title: String,
-    pub agent_name: String,
 }
 
 /// Generate an issue title using the configured LLM agent
@@ -115,7 +114,6 @@ pub async fn generate_title(
 
     Ok(GeneratedTitle {
         title,
-        agent_name: agent.name.clone(),
     })
 }
 

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -22,23 +22,3 @@ pub use work::{
 };
 #[allow(unused_imports)]
 pub use generate::{generate_title, GeneratedTitle, TitleGenerationError};
-
-use thiserror::Error;
-
-#[derive(Error, Debug)]
-pub enum LlmError {
-    #[error("Config error: {0}")]
-    ConfigError(#[from] LocalConfigError),
-
-    #[error("Agent error: {0}")]
-    AgentError(#[from] AgentError),
-
-    #[error("Prompt error: {0}")]
-    PromptError(#[from] PromptError),
-
-    #[error("Work tracking error: {0}")]
-    WorkTrackingError(#[from] WorkTrackingError),
-
-    #[error("Issue error: {0}")]
-    IssueError(#[from] crate::issue::IssueCrudError),
-}

--- a/src/llm/prompt.rs
+++ b/src/llm/prompt.rs
@@ -43,7 +43,7 @@ impl LlmAction {
     }
 
     /// Convert to proto enum value
-    #[must_use]
+    #[cfg(test)]
     pub fn to_proto(&self) -> i32 {
         match self {
             LlmAction::Plan => 1,

--- a/src/llm/work.rs
+++ b/src/llm/work.rs
@@ -123,19 +123,6 @@ pub fn is_process_running(_pid: u32) -> bool {
     true
 }
 
-/// Check if there's active work and if the process is still running
-pub async fn get_active_work_status(
-    project_path: &Path,
-) -> Result<Option<(LlmWorkSession, bool)>, WorkTrackingError> {
-    match read_work_session(project_path).await? {
-        Some(session) => {
-            let is_running = session.pid.is_some_and(is_process_running);
-            Ok(Some((session, is_running)))
-        }
-        None => Ok(None),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -14,9 +14,6 @@ pub enum ManifestError {
 
     #[error("Failed to parse manifest: {0}")]
     ParseError(#[from] serde_json::Error),
-
-    #[error("Manifest not found at {0}")]
-    NotFound(String),
 }
 
 /// Read the manifest from the project path

--- a/src/migration/types.rs
+++ b/src/migration/types.rs
@@ -14,12 +14,6 @@ pub enum MigrationError {
     #[error("JSON error: {0}")]
     JsonError(#[from] serde_json::Error),
 
-    #[error("Migration {0} failed: {1}")]
-    MigrationFailed(String, String),
-
-    #[error("Rollback failed for migration {0}: {1}")]
-    RollbackFailed(String, String),
-
     #[error("Version error: {0}")]
     VersionError(#[from] crate::version::VersionError),
 

--- a/src/pr/create.rs
+++ b/src/pr/create.rs
@@ -43,15 +43,6 @@ pub enum PrError {
 
     #[error("Reconcile error: {0}")]
     ReconcileError(#[from] ReconcileError),
-
-    #[error("Not a git repository")]
-    NotGitRepository,
-
-    #[error("Source branch '{0}' does not exist")]
-    SourceBranchNotFound(String),
-
-    #[error("Target branch '{0}' does not exist")]
-    TargetBranchNotFound(String),
 }
 
 /// Options for creating a PR
@@ -70,8 +61,6 @@ pub struct CreatePrOptions {
     /// Initial status. Defaults to "draft".
     pub status: Option<String>,
     pub custom_fields: HashMap<String, String>,
-    /// Optional template name (without .md extension)
-    pub template: Option<String>,
 }
 
 /// Result of PR creation

--- a/src/pr/git.rs
+++ b/src/pr/git.rs
@@ -17,9 +17,6 @@ pub enum GitError {
     #[error("Failed to execute git command: {0}")]
     CommandError(String),
 
-    #[error("Branch '{0}' does not exist")]
-    BranchNotFound(String),
-
     #[error("Failed to detect current branch")]
     CurrentBranchNotFound,
 

--- a/src/search/ast.rs
+++ b/src/search/ast.rs
@@ -81,8 +81,6 @@ pub enum Operator {
     Gte,
     /// Less than or equal (`<=`)
     Lte,
-    /// Wildcard pattern (`:` with `*` or `?`)
-    Wildcard,
 }
 
 impl Operator {

--- a/src/search/error.rs
+++ b/src/search/error.rs
@@ -5,9 +5,6 @@ pub enum SearchError {
     #[error("Query parse error: {0}")]
     ParseError(String),
 
-    #[error("Invalid field '{0}': {1}")]
-    InvalidField(String, String),
-
     #[error("Invalid operator '{0}' for field '{1}'")]
     InvalidOperator(String, String),
 
@@ -19,9 +16,6 @@ pub enum SearchError {
 
     #[error("Invalid regex pattern '{0}': {1}")]
     InvalidRegex(String, String),
-
-    #[error("Project not found: {0}")]
-    ProjectNotFound(String),
 
     #[error("Issue error: {0}")]
     IssueError(String),

--- a/src/search/evaluator.rs
+++ b/src/search/evaluator.rs
@@ -89,7 +89,6 @@ fn evaluate_string_condition(operator: &Operator, field_value: &str, query_value
                 Operator::Lt => field_lower < query_lower,
                 Operator::Gte => field_lower >= query_lower,
                 Operator::Lte => field_lower <= query_lower,
-                Operator::Wildcard => false, // Handled by Pattern
             }
         }
         Value::Pattern(pattern) => {
@@ -112,7 +111,7 @@ fn evaluate_number_condition(operator: &Operator, field_value: i64, query_value:
                 Operator::Gte => field_value >= *n,
                 Operator::Lte => field_value <= *n,
                 // These don't make sense for numbers
-                Operator::Contains | Operator::StartsWith | Operator::EndsWith | Operator::Wildcard => false,
+                Operator::Contains | Operator::StartsWith | Operator::EndsWith => false,
             }
         }
         // Other value types don't match numbers
@@ -146,7 +145,7 @@ fn evaluate_date_condition(operator: &Operator, field_value: &NaiveDate, query_v
                 Operator::Gte => field_value >= d,
                 Operator::Lte => field_value <= d,
                 // These don't make sense for dates
-                Operator::Contains | Operator::StartsWith | Operator::EndsWith | Operator::Wildcard => false,
+                Operator::Contains | Operator::StartsWith | Operator::EndsWith => false,
             }
         }
         // Other value types don't match dates

--- a/src/search/executor.rs
+++ b/src/search/executor.rs
@@ -65,8 +65,6 @@ impl std::str::FromStr for SortField {
 pub struct SearchResult {
     /// Matching issues with project info
     pub results: Vec<SearchResultIssue>,
-    /// Total count of results
-    pub total_count: usize,
     /// Debug: the parsed query representation
     pub parsed_query: String,
 }
@@ -101,11 +99,8 @@ pub async fn advanced_search(options: SearchOptions) -> Result<SearchResult, Sea
         sort_results(&mut results, sort);
     }
 
-    let total_count = results.len();
-
     Ok(SearchResult {
         results,
-        total_count,
         parsed_query,
     })
 }

--- a/src/search/parser.rs
+++ b/src/search/parser.rs
@@ -351,7 +351,6 @@ fn format_operator(op: &Operator) -> String {
         Operator::Lt => "<".to_string(),
         Operator::Gte => ">=".to_string(),
         Operator::Lte => "<=".to_string(),
-        Operator::Wildcard => ":".to_string(),
     }
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1884,7 +1884,6 @@ impl CentyDaemon for CentyDaemonService {
             priority: if req.priority == 0 { None } else { Some(req.priority as u32) },
             status: if req.status.is_empty() { None } else { Some(req.status) },
             custom_fields: req.custom_fields,
-            template: if req.template.is_empty() { None } else { Some(req.template) },
         };
 
         match create_pr(project_path, options).await {

--- a/src/sync/conflicts.rs
+++ b/src/sync/conflicts.rs
@@ -37,6 +37,7 @@ pub struct ConflictInfo {
 
 impl ConflictInfo {
     /// Create a new conflict info
+    #[allow(dead_code)] // Part of sync feature infrastructure
     pub fn new(
         item_type: &str,
         item_id: &str,
@@ -59,7 +60,7 @@ impl ConflictInfo {
     }
 
     /// Set a description for the conflict
-    #[must_use]
+    #[allow(dead_code)] // Part of sync feature infrastructure
     pub fn with_description(mut self, description: &str) -> Self {
         self.description = Some(description.to_string());
         self
@@ -86,6 +87,7 @@ fn get_conflicts_dir(sync_path: &Path) -> PathBuf {
 /// Store a conflict for later resolution.
 ///
 /// Returns the path where the conflict was stored.
+#[allow(dead_code)] // Part of sync feature infrastructure
 pub async fn store_conflict(
     sync_path: &Path,
     item_type: &str,
@@ -223,6 +225,7 @@ pub async fn resolve_conflict(
 }
 
 /// Get conflicts for a specific item
+#[allow(dead_code)] // Part of sync feature infrastructure
 pub async fn get_conflicts_for_item(
     sync_path: &Path,
     item_type: &str,
@@ -237,6 +240,7 @@ pub async fn get_conflicts_for_item(
 }
 
 /// Check if an item has any unresolved conflicts
+#[allow(dead_code)] // Part of sync feature infrastructure
 pub async fn has_conflicts(
     sync_path: &Path,
     item_type: &str,
@@ -247,6 +251,7 @@ pub async fn has_conflicts(
 }
 
 /// Clear all conflicts (use with caution)
+#[allow(dead_code)] // Part of sync feature infrastructure
 pub async fn clear_all_conflicts(sync_path: &Path) -> Result<usize, SyncError> {
     let conflicts_dir = get_conflicts_dir(sync_path);
 

--- a/src/sync/manager.rs
+++ b/src/sync/manager.rs
@@ -100,6 +100,7 @@ impl CentySyncManager {
     /// Create a new sync manager in local-only mode.
     ///
     /// This is used when there's no remote origin configured.
+    #[allow(dead_code)] // Part of sync feature infrastructure
     pub async fn new_local_only(project_path: &Path) -> Result<Self, SyncError> {
         let project_path = project_path.to_path_buf();
 
@@ -133,13 +134,13 @@ impl CentySyncManager {
     }
 
     /// Get the sync worktree path
-    #[must_use]
+    #[allow(dead_code)] // Part of sync feature infrastructure
     pub fn worktree_path(&self) -> &Path {
         &self.sync_worktree
     }
 
     /// Get the original project path
-    #[must_use]
+    #[allow(dead_code)] // Part of sync feature infrastructure
     pub fn project_path(&self) -> &Path {
         &self.project_path
     }
@@ -157,7 +158,7 @@ impl CentySyncManager {
     }
 
     /// Check if remote sync is available
-    #[must_use]
+    #[allow(dead_code)] // Part of sync feature infrastructure
     pub fn has_remote(&self) -> bool {
         self.mode == SyncMode::Full
     }
@@ -301,6 +302,7 @@ impl CentySyncManager {
     }
 
     /// Process any pending push operations
+    #[allow(dead_code)] // Part of sync feature infrastructure
     pub async fn process_pending_push(&self) -> Result<bool, SyncError> {
         if self.mode != SyncMode::Full {
             return Ok(false);
@@ -386,6 +388,7 @@ impl CentySyncManager {
     }
 
     /// Repair the sync worktree if it's corrupted
+    #[allow(dead_code)] // Part of sync feature infrastructure
     pub async fn repair(&mut self) -> Result<(), SyncError> {
         if self.mode == SyncMode::Disabled {
             return Ok(());

--- a/src/sync/merge.rs
+++ b/src/sync/merge.rs
@@ -8,6 +8,7 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 
 /// Result of a merge operation
+#[allow(dead_code)] // Part of sync feature infrastructure
 #[derive(Debug, Clone)]
 pub enum MergeResult<T> {
     /// Clean merge, no conflicts
@@ -27,7 +28,7 @@ pub enum MergeResult<T> {
 
 impl<T> MergeResult<T> {
     /// Check if the merge was clean (no conflicts)
-    #[must_use]
+    #[allow(dead_code)] // Part of sync feature infrastructure
     pub fn is_clean(&self) -> bool {
         matches!(
             self,
@@ -36,6 +37,7 @@ impl<T> MergeResult<T> {
     }
 
     /// Get the merged value if the merge was clean
+    #[allow(dead_code)] // Part of sync feature infrastructure
     pub fn into_value(self) -> Option<T> {
         match self {
             MergeResult::Clean(v) | MergeResult::TakeOurs(v) | MergeResult::TakeTheirs(v) => {
@@ -53,6 +55,7 @@ impl<T> MergeResult<T> {
 /// - If base == theirs && base != ours → take ours
 /// - If base != ours && base != theirs && ours != theirs → conflict
 /// - If ours == theirs → take either (same)
+#[allow(dead_code)] // Part of sync feature infrastructure
 pub fn merge_json_metadata(base: &Value, ours: &Value, theirs: &Value) -> MergeResult<Value> {
     // If ours == theirs, no conflict
     if ours == theirs {
@@ -90,6 +93,7 @@ pub fn merge_json_metadata(base: &Value, ours: &Value, theirs: &Value) -> MergeR
 }
 
 /// Merge two JSON objects field by field
+#[allow(dead_code)] // Part of sync feature infrastructure
 fn merge_json_objects(
     base: &Map<String, Value>,
     ours: &Map<String, Value>,
@@ -197,6 +201,7 @@ fn merge_json_objects(
 ///
 /// If only one side changed, take that change.
 /// If both sides changed, return a conflict.
+#[allow(dead_code)] // Part of sync feature infrastructure
 pub fn merge_markdown(base: &str, ours: &str, theirs: &str) -> MergeResult<String> {
     // If ours == theirs, no conflict
     if ours == theirs {
@@ -221,7 +226,7 @@ pub fn merge_markdown(base: &str, ours: &str, theirs: &str) -> MergeResult<Strin
 }
 
 /// Check if content has git conflict markers
-#[must_use]
+#[allow(dead_code)] // Part of sync feature infrastructure
 pub fn has_conflict_markers(content: &str) -> bool {
     content.contains("<<<<<<<") && content.contains("=======") && content.contains(">>>>>>>")
 }
@@ -230,6 +235,7 @@ pub fn has_conflict_markers(content: &str) -> bool {
 ///
 /// When merging, two issues might end up with the same display number.
 /// This function detects and resolves such collisions by renumbering.
+#[allow(dead_code)] // Part of sync feature infrastructure
 pub async fn resolve_display_number_collisions(
     sync_path: &std::path::Path,
 ) -> Result<Vec<RenumberedItem>, super::SyncError> {
@@ -311,6 +317,7 @@ pub async fn resolve_display_number_collisions(
 }
 
 /// Information about a renumbered item after collision resolution
+#[allow(dead_code)] // Part of sync feature infrastructure
 #[derive(Debug, Clone)]
 pub struct RenumberedItem {
     /// The issue/doc/PR ID

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -60,7 +60,6 @@ pub use worktree::{
     sync_worktree_exists,
 };
 
-use std::path::PathBuf;
 use thiserror::Error;
 
 /// The name of the centy sync branch
@@ -69,23 +68,11 @@ pub const CENTY_BRANCH: &str = "centy";
 /// Error types for sync operations
 #[derive(Error, Debug)]
 pub enum SyncError {
-    #[error("Not a git repository")]
-    NotGitRepository,
-
-    #[error("No remote 'origin' configured")]
-    NoRemote,
-
     #[error("Worktree error: {0}")]
     WorktreeError(String),
 
     #[error("Git command failed: {0}")]
     GitCommandFailed(String),
-
-    #[error("Merge conflict in {file}")]
-    MergeConflict {
-        file: String,
-        conflict_path: PathBuf,
-    },
 
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
@@ -95,9 +82,6 @@ pub enum SyncError {
 
     #[error("Home directory not found")]
     HomeDirNotFound,
-
-    #[error("Sync is disabled for this project (local-only mode)")]
-    SyncDisabled,
 
     #[error("Conflict not found: {0}")]
     ConflictNotFound(String),

--- a/src/sync/sync_aware.rs
+++ b/src/sync/sync_aware.rs
@@ -123,6 +123,7 @@ pub async fn get_issue_by_display_number(
 /// Create a new issue (sync-aware).
 ///
 /// Commits and pushes after creation.
+#[allow(dead_code)] // Part of sync feature infrastructure
 pub async fn create_issue(
     project_path: &Path,
     options: CreateIssueOptions,

--- a/src/sync/worktree.rs
+++ b/src/sync/worktree.rs
@@ -103,6 +103,7 @@ pub async fn ensure_sync_worktree(project_path: &Path) -> Result<PathBuf, SyncEr
 }
 
 /// Remove sync worktree and prune references
+#[allow(dead_code)] // Part of sync feature infrastructure
 pub async fn remove_sync_worktree(project_path: &Path) -> Result<(), SyncError> {
     let worktree_path = get_sync_worktree_path(project_path)?;
 
@@ -146,12 +147,14 @@ pub async fn remove_sync_worktree(project_path: &Path) -> Result<(), SyncError> 
 /// Get the .centy path within sync worktree.
 ///
 /// Returns: `{sync_worktree}/.centy/`
+#[allow(dead_code)] // Part of sync feature infrastructure
 pub fn get_sync_centy_path(project_path: &Path) -> Result<PathBuf, SyncError> {
     let worktree_path = get_sync_worktree_path(project_path)?;
     Ok(worktree_path.join(".centy"))
 }
 
 /// Validate that a worktree is properly set up
+#[allow(dead_code)] // Part of sync feature infrastructure
 pub fn validate_worktree(worktree_path: &Path) -> Result<bool, SyncError> {
     // Check .git file exists (worktrees have a .git file, not directory)
     let git_file = worktree_path.join(".git");
@@ -170,6 +173,7 @@ pub fn validate_worktree(worktree_path: &Path) -> Result<bool, SyncError> {
 }
 
 /// Repair a corrupted worktree by recreating it
+#[allow(dead_code)] // Part of sync feature infrastructure
 pub async fn repair_worktree(project_path: &Path) -> Result<PathBuf, SyncError> {
     // Remove existing worktree
     remove_sync_worktree(project_path).await?;

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -34,6 +34,7 @@ pub fn compare_versions(project_version: &SemVer, daemon_version: &SemVer) -> Ve
 /// a warning if the project version is newer than the daemon version.
 ///
 /// Returns the version comparison result.
+#[allow(dead_code)] // Reserved for version compatibility checks
 pub async fn check_version_for_operation(project_path: &Path) -> VersionComparison {
     let daemon_ver = daemon_version();
 

--- a/src/version/types.rs
+++ b/src/version/types.rs
@@ -13,9 +13,6 @@ pub use semver::Version as SemVer;
 pub enum VersionError {
     #[error("Invalid version format: {0}")]
     InvalidFormat(String),
-
-    #[error("Version not found in config")]
-    NotFound,
 }
 
 impl From<semver::Error> for VersionError {

--- a/src/workspace/cleanup.rs
+++ b/src/workspace/cleanup.rs
@@ -149,6 +149,7 @@ pub async fn cleanup_expired_workspaces() -> Result<Vec<CleanupResult>, Workspac
 }
 
 /// Count successfully cleaned workspaces
+#[allow(dead_code)] // Utility for workspace cleanup reporting
 pub fn count_cleaned(results: &[CleanupResult]) -> u32 {
     results
         .iter()
@@ -157,6 +158,7 @@ pub fn count_cleaned(results: &[CleanupResult]) -> u32 {
 }
 
 /// Get paths that failed to clean
+#[allow(dead_code)] // Utility for workspace cleanup reporting
 pub fn get_failed_paths(results: &[CleanupResult]) -> Vec<String> {
     results
         .iter()
@@ -166,6 +168,7 @@ pub fn get_failed_paths(results: &[CleanupResult]) -> Vec<String> {
 }
 
 /// Get paths that were successfully cleaned
+#[allow(dead_code)] // Utility for workspace cleanup reporting
 pub fn get_cleaned_paths(results: &[CleanupResult]) -> Vec<String> {
     results
         .iter()

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -47,20 +47,11 @@ pub enum WorkspaceError {
     #[error("Git error: {0}")]
     GitError(String),
 
-    #[error("VS Code not found in PATH")]
-    VscodeNotFound,
-
     #[error("VS Code failed to open: {0}")]
     VscodeError(String),
 
-    #[error("Terminal not found")]
-    TerminalNotFound,
-
     #[error("Terminal failed to open: {0}")]
     TerminalError(String),
-
-    #[error("Workspace not found: {0}")]
-    WorkspaceNotFound(String),
 
     #[error("Issue error: {0}")]
     IssueError(#[from] crate::issue::IssueCrudError),

--- a/src/workspace/storage.rs
+++ b/src/workspace/storage.rs
@@ -47,6 +47,7 @@ pub async fn read_registry() -> Result<WorkspaceRegistry, WorkspaceError> {
 }
 
 /// Write the workspace registry to disk with locking and atomic write
+#[allow(dead_code)] // Part of workspace management infrastructure
 pub async fn write_registry(registry: &WorkspaceRegistry) -> Result<(), WorkspaceError> {
     let _guard = get_lock().lock().await;
     write_registry_unlocked(registry).await
@@ -196,6 +197,7 @@ pub async fn list_workspaces(
 }
 
 /// Count expired workspaces
+#[allow(dead_code)] // Part of workspace management infrastructure
 pub async fn count_expired() -> Result<u32, WorkspaceError> {
     let registry = read_registry().await?;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+//! Common test utilities
 
 use std::path::Path;
 use tempfile::TempDir;
@@ -19,6 +19,7 @@ pub async fn init_centy_project(project_path: &Path) {
 }
 
 /// Verify that the .centy folder exists with expected structure
+#[allow(dead_code)] // Test utility for integration tests
 pub fn verify_centy_structure(project_path: &Path) {
     let centy_path = project_path.join(".centy");
     assert!(centy_path.exists(), ".centy folder should exist");

--- a/tests/pr_test.rs
+++ b/tests/pr_test.rs
@@ -26,7 +26,6 @@ async fn test_create_pr_success() {
         status: Some("draft".to_string()),
         reviewers: vec!["reviewer1".to_string()],
         custom_fields: HashMap::new(),
-        ..Default::default()
     };
 
     let result = create_pr(project_path, options)


### PR DESCRIPTION
## Summary

- Remove the global `dead_code = "allow"` lint from `Cargo.toml`
- Remove genuinely unused code (~207 lines of dead code eliminated)
- Add targeted `#[allow(dead_code)]` with explanatory comments for intentionally kept infrastructure code (sync/, features/, workspace/)

This ensures dead code warnings are properly addressed rather than globally suppressed, improving code quality and making it easier to catch actually unused code in the future.

## Test plan

- [x] `cargo build` passes with zero warnings
- [x] `cargo clippy` passes with zero warnings  
- [x] All 286 tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)