### PR TITLE
chore: add explanatory comments to #[allow(dead_code)] annotations

### DIFF
--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -2,8 +2,9 @@ mod crud;
 mod instruction;
 mod types;
 
+// Feature module exports - WIP functionality for issue compaction and migration
 #[allow(unused_imports)]
-#[allow(dead_code)]
+#[allow(dead_code)] // Part of WIP features module
 pub use crud::{
     build_compacted_refs, generate_migration_frontmatter, get_compact, get_feature_status,
     get_instruction, list_uncompacted_issues, mark_issues_compacted, save_migration,
@@ -12,5 +13,5 @@ pub use crud::{
 #[allow(unused_imports)]
 pub use instruction::DEFAULT_INSTRUCTION_CONTENT;
 #[allow(unused_imports)]
-#[allow(dead_code)]
+#[allow(dead_code)] // Part of WIP features module
 pub use types::{CompactedIssueRef, FeatureStatus, MigrationFrontmatter};

--- a/src/item/entities/pr/id.rs
+++ b/src/item/entities/pr/id.rs
@@ -26,7 +26,7 @@ pub fn generate_pr_id() -> String {
 
 /// Get the short form of a PR ID (first 8 characters)
 /// Useful for display purposes
-#[allow(dead_code)]
+#[allow(dead_code)] // Utility function for future CLI display features
 #[must_use]
 pub fn short_id(id: &str) -> &str {
     if id.len() >= 8 {

--- a/src/registry/storage.rs
+++ b/src/registry/storage.rs
@@ -75,7 +75,7 @@ pub async fn read_registry() -> Result<ProjectRegistry, RegistryError> {
 }
 
 /// Write the registry to disk with locking and atomic write
-#[allow(dead_code)]
+#[allow(dead_code)] // Public API for external callers, internal code uses write_registry_unlocked
 pub async fn write_registry(registry: &ProjectRegistry) -> Result<(), RegistryError> {
     let _guard = get_lock().lock().await;
     write_registry_unlocked(registry).await


### PR DESCRIPTION
## Summary

- Add explanatory comments to all `#[allow(dead_code)]` annotations that were missing them
- registry/storage.rs: `write_registry` is public API for external callers
- features/mod.rs: Part of WIP features module for issue compaction
- item/entities/pr/id.rs: Utility for future CLI display features

This completes the cleanup of dead_code lint handling after the global allow was removed from Cargo.toml.

Closes: centy-daemon#109

## Test plan

- [x] `cargo build` passes with no dead code warnings
- [x] `cargo clippy` passes (only unrelated too_many_lines warning)
- [x] All existing tests pass (373 unit tests + integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)