### PR TITLE
feat(workspace): add standalone workspace support

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,10 +2,10 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "Plan Issue #113",
+      "label": "Plan Issue #115",
       "type": "shell",
       "command": "centy",
-      "args": ["issue", "d6d89011-3941-499e-82eb-02d66194dc69", "--action", "plan"],
+      "args": ["issue", "92753fbd-30de-4587-854d-ebe4d56d2e6b", "--action", "plan"],
       "presentation": {
         "reveal": "always",
         "panel": "new",

--- a/proto/centy.proto
+++ b/proto/centy.proto
@@ -264,6 +264,12 @@ service CentyDaemon {
   // Open an agent in a terminal for working on an issue
   rpc OpenAgentInTerminal(OpenAgentInTerminalRequest) returns (OpenAgentInTerminalResponse);
 
+  // Open a standalone workspace in VS Code (not tied to an issue)
+  rpc OpenStandaloneWorkspaceVscode(OpenStandaloneWorkspaceRequest) returns (OpenStandaloneWorkspaceResponse);
+
+  // Open a standalone workspace in terminal (not tied to an issue)
+  rpc OpenStandaloneWorkspaceTerminal(OpenStandaloneWorkspaceRequest) returns (OpenStandaloneWorkspaceResponse);
+
   // List all temp workspaces
   rpc ListTempWorkspaces(ListTempWorkspacesRequest) returns (ListTempWorkspacesResponse);
 
@@ -1663,17 +1669,43 @@ message OpenAgentInTerminalResponse {
   bool requires_status_config = 9;      // True if user must configure update_status_on_start setting
 }
 
+// Request to open a standalone workspace (not tied to an issue)
+message OpenStandaloneWorkspaceRequest {
+  string project_path = 1;              // Source project path
+  string name = 2;                      // Optional custom name for the workspace
+  string description = 3;               // Optional description/goals for this workspace
+  uint32 ttl_hours = 4;                 // Custom TTL in hours (0 = use default 12h)
+  string agent_name = 5;                // Agent to use (empty = default)
+}
+
+// Response for opening a standalone workspace
+message OpenStandaloneWorkspaceResponse {
+  bool success = 1;
+  string error = 2;
+  string workspace_path = 3;            // Path to the temp workspace
+  string workspace_id = 4;              // Unique workspace identifier (UUID)
+  string name = 5;                      // Workspace name (provided or generated)
+  string expires_at = 6;                // ISO timestamp when workspace expires
+  bool editor_opened = 7;               // Whether the editor was successfully opened
+  bool workspace_reused = 8;            // True if an existing workspace was reopened
+  string original_created_at = 9;       // Original creation timestamp (only set if workspace_reused)
+}
+
 // A temporary workspace entry
 message TempWorkspace {
   string workspace_path = 1;            // Absolute path to temp workspace
   string source_project_path = 2;       // Original project path
-  string issue_id = 3;                  // Issue UUID
-  uint32 issue_display_number = 4;      // Issue display number
-  string issue_title = 5;               // Issue title
+  string issue_id = 3;                  // Issue UUID (empty for standalone workspaces)
+  uint32 issue_display_number = 4;      // Issue display number (0 for standalone)
+  string issue_title = 5;               // Issue title (empty for standalone)
   string agent_name = 6;                // Agent being used
   LlmAction action = 7;                 // Plan or Implement
   string created_at = 8;                // ISO timestamp
   string expires_at = 9;                // ISO timestamp when workspace expires
+  bool is_standalone = 10;              // True if this is a standalone workspace (not tied to an issue)
+  string workspace_id = 11;             // Unique workspace ID (UUID, used for standalone workspaces)
+  string workspace_name = 12;           // Custom workspace name (for standalone)
+  string workspace_description = 13;    // Custom workspace description (for standalone)
 }
 
 message ListTempWorkspacesRequest {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -77,11 +77,11 @@ use crate::user::{
 use crate::utils::{format_display_path, get_centy_path, CENTY_VERSION};
 use crate::workspace::{
     cleanup_expired_workspaces as internal_cleanup_expired,
-    cleanup_workspace as internal_cleanup_workspace, create_temp_workspace,
-    list_workspaces as internal_list_workspaces,
+    cleanup_workspace as internal_cleanup_workspace, create_standalone_workspace,
+    create_temp_workspace, list_workspaces as internal_list_workspaces,
     terminal::{is_terminal_available, open_terminal_with_agent},
     vscode::is_vscode_available,
-    CreateWorkspaceOptions, EditorType,
+    CreateStandaloneWorkspaceOptions, CreateWorkspaceOptions, EditorType,
 };
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -136,7 +136,8 @@ use proto::{
     ListUsersRequest, ListUsersResponse, LlmConfig, LlmWorkSession, LocalLlmConfig, Manifest,
     MarkIssuesCompactedRequest, MarkIssuesCompactedResponse, MoveDocRequest, MoveDocResponse,
     MoveIssueRequest, MoveIssueResponse, OpenAgentInTerminalRequest, OpenAgentInTerminalResponse,
-    OpenInTempWorkspaceRequest, OpenInTempWorkspaceResponse, OrgDocSyncResult,
+    OpenInTempWorkspaceRequest, OpenInTempWorkspaceResponse, OpenStandaloneWorkspaceRequest,
+    OpenStandaloneWorkspaceResponse, OrgDocSyncResult,
     OrgInferenceResult as ProtoOrgInferenceResult, Organization as ProtoOrganization, PrMetadata,
     PrWithProject as ProtoPrWithProject, ProjectVersionInfo, PullRequest, ReconciliationPlan,
     RegisterProjectRequest, RegisterProjectResponse, RestartRequest, RestartResponse,
@@ -3812,12 +3813,17 @@ impl CentyDaemon for CentyDaemonService {
                         issue_title: entry.issue_title,
                         agent_name: entry.agent_name,
                         action: match entry.action.as_str() {
-                            "plan" => 1,      // LLM_ACTION_PLAN
-                            "implement" => 2, // LLM_ACTION_IMPLEMENT
+                            "plan" => 1,       // LLM_ACTION_PLAN
+                            "implement" => 2,  // LLM_ACTION_IMPLEMENT
+                            "standalone" => 0, // No specific action for standalone
                             _ => 0,
                         },
                         created_at: entry.created_at,
                         expires_at: entry.expires_at,
+                        is_standalone: entry.is_standalone,
+                        workspace_id: entry.workspace_id,
+                        workspace_name: entry.workspace_name,
+                        workspace_description: entry.workspace_description,
                     })
                     .collect();
 
@@ -3886,6 +3892,144 @@ impl CentyDaemon for CentyDaemonService {
                 cleaned_paths: vec![],
                 failed_paths: vec![],
             })),
+        }
+    }
+
+    async fn open_standalone_workspace_vscode(
+        &self,
+        request: Request<OpenStandaloneWorkspaceRequest>,
+    ) -> Result<Response<OpenStandaloneWorkspaceResponse>, Status> {
+        let req = request.into_inner();
+        track_project_async(req.project_path.clone());
+        let project_path = Path::new(&req.project_path);
+
+        let err_response = |error: String| {
+            Ok(Response::new(OpenStandaloneWorkspaceResponse {
+                success: false,
+                error,
+                workspace_path: String::new(),
+                workspace_id: String::new(),
+                name: String::new(),
+                expires_at: String::new(),
+                editor_opened: false,
+                workspace_reused: false,
+                original_created_at: String::new(),
+            }))
+        };
+
+        let llm_config = get_effective_local_config(Some(project_path)).await.ok();
+        let agent_name = if req.agent_name.is_empty() {
+            llm_config
+                .as_ref()
+                .and_then(|c| c.default_agent.clone())
+                .unwrap_or_else(|| "default".to_string())
+        } else {
+            req.agent_name.clone()
+        };
+
+        let name = if req.name.is_empty() {
+            None
+        } else {
+            Some(req.name.clone())
+        };
+
+        let description = if req.description.is_empty() {
+            None
+        } else {
+            Some(req.description.clone())
+        };
+
+        match create_standalone_workspace(CreateStandaloneWorkspaceOptions {
+            source_project_path: project_path.to_path_buf(),
+            name,
+            description,
+            ttl_hours: req.ttl_hours,
+            agent_name,
+            editor: EditorType::VSCode,
+        })
+        .await
+        {
+            Ok(result) => Ok(Response::new(OpenStandaloneWorkspaceResponse {
+                success: true,
+                error: String::new(),
+                workspace_path: result.workspace_path.to_string_lossy().to_string(),
+                workspace_id: result.entry.workspace_id.clone(),
+                name: result.entry.workspace_name.clone(),
+                expires_at: result.entry.expires_at,
+                editor_opened: result.editor_opened,
+                workspace_reused: result.workspace_reused,
+                original_created_at: result.original_created_at.unwrap_or_default(),
+            })),
+            Err(e) => err_response(e.to_string()),
+        }
+    }
+
+    async fn open_standalone_workspace_terminal(
+        &self,
+        request: Request<OpenStandaloneWorkspaceRequest>,
+    ) -> Result<Response<OpenStandaloneWorkspaceResponse>, Status> {
+        let req = request.into_inner();
+        track_project_async(req.project_path.clone());
+        let project_path = Path::new(&req.project_path);
+
+        let err_response = |error: String| {
+            Ok(Response::new(OpenStandaloneWorkspaceResponse {
+                success: false,
+                error,
+                workspace_path: String::new(),
+                workspace_id: String::new(),
+                name: String::new(),
+                expires_at: String::new(),
+                editor_opened: false,
+                workspace_reused: false,
+                original_created_at: String::new(),
+            }))
+        };
+
+        let llm_config = get_effective_local_config(Some(project_path)).await.ok();
+        let agent_name = if req.agent_name.is_empty() {
+            llm_config
+                .as_ref()
+                .and_then(|c| c.default_agent.clone())
+                .unwrap_or_else(|| "default".to_string())
+        } else {
+            req.agent_name.clone()
+        };
+
+        let name = if req.name.is_empty() {
+            None
+        } else {
+            Some(req.name.clone())
+        };
+
+        let description = if req.description.is_empty() {
+            None
+        } else {
+            Some(req.description.clone())
+        };
+
+        match create_standalone_workspace(CreateStandaloneWorkspaceOptions {
+            source_project_path: project_path.to_path_buf(),
+            name,
+            description,
+            ttl_hours: req.ttl_hours,
+            agent_name,
+            editor: EditorType::Terminal,
+        })
+        .await
+        {
+            Ok(result) => Ok(Response::new(OpenStandaloneWorkspaceResponse {
+                success: true,
+                error: String::new(),
+                workspace_path: result.workspace_path.to_string_lossy().to_string(),
+                workspace_id: result.entry.workspace_id.clone(),
+                name: result.entry.workspace_name.clone(),
+                expires_at: result.entry.expires_at,
+                editor_opened: result.editor_opened,
+                workspace_reused: result.workspace_reused,
+                original_created_at: result.original_created_at.unwrap_or_default(),
+            })),
+            Err(e) => err_response(e.to_string()),
         }
     }
 

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -16,12 +16,13 @@ pub mod vscode;
 pub use cleanup::{cleanup_expired_workspaces, cleanup_workspace, CleanupResult};
 #[allow(unused_imports)]
 pub use create::{
-    create_temp_workspace, CreateWorkspaceOptions, CreateWorkspaceResult, EditorType,
+    create_standalone_workspace, create_temp_workspace, CreateStandaloneWorkspaceOptions,
+    CreateStandaloneWorkspaceResult, CreateWorkspaceOptions, CreateWorkspaceResult, EditorType,
 };
 #[allow(unused_imports)]
 pub use storage::{
-    add_workspace, find_workspace_for_issue, get_workspace, list_workspaces, read_registry,
-    remove_workspace, update_workspace_expiration, write_registry,
+    add_workspace, find_standalone_workspace, find_workspace_for_issue, get_workspace,
+    list_workspaces, read_registry, remove_workspace, update_workspace_expiration, write_registry,
 };
 #[allow(unused_imports)]
 pub use terminal::{is_terminal_available, open_terminal, open_terminal_with_agent};

--- a/src/workspace/types.rs
+++ b/src/workspace/types.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Current schema version for workspace registry
-pub const CURRENT_WORKSPACE_SCHEMA: u32 = 1;
+pub const CURRENT_WORKSPACE_SCHEMA: u32 = 2;
 
 /// Default TTL for workspaces in hours
 pub const DEFAULT_TTL_HOURS: u32 = 12;
@@ -16,19 +16,22 @@ pub struct TempWorkspaceEntry {
     /// Path to the source project that was cloned
     pub source_project_path: String,
 
-    /// Issue UUID
+    /// Issue UUID (empty for standalone workspaces)
+    #[serde(default)]
     pub issue_id: String,
 
-    /// Human-readable issue display number
+    /// Human-readable issue display number (0 for standalone)
+    #[serde(default)]
     pub issue_display_number: u32,
 
-    /// Issue title for reference
+    /// Issue title for reference (empty for standalone)
+    #[serde(default)]
     pub issue_title: String,
 
     /// Name of the agent configured for this workspace
     pub agent_name: String,
 
-    /// Action type: "plan" or "implement"
+    /// Action type: "plan", "implement", or "standalone"
     pub action: String,
 
     /// ISO timestamp when workspace was created
@@ -39,6 +42,22 @@ pub struct TempWorkspaceEntry {
 
     /// Git ref used for the worktree (usually "HEAD")
     pub worktree_ref: String,
+
+    /// Whether this is a standalone workspace (not tied to an issue)
+    #[serde(default)]
+    pub is_standalone: bool,
+
+    /// Unique workspace ID (UUID, generated for standalone workspaces)
+    #[serde(default)]
+    pub workspace_id: String,
+
+    /// Custom workspace name (for standalone workspaces)
+    #[serde(default)]
+    pub workspace_name: String,
+
+    /// Custom workspace description/goals (for standalone workspaces)
+    #[serde(default)]
+    pub workspace_description: String,
 }
 
 /// Registry of all temporary workspaces
@@ -106,6 +125,10 @@ mod tests {
             created_at: "2025-01-01T00:00:00Z".to_string(),
             expires_at: "2025-01-01T12:00:00Z".to_string(),
             worktree_ref: "HEAD".to_string(),
+            is_standalone: false,
+            workspace_id: String::new(),
+            workspace_name: String::new(),
+            workspace_description: String::new(),
         };
 
         let json = serde_json::to_string(&entry).unwrap();
@@ -114,5 +137,53 @@ mod tests {
 
         let deserialized: TempWorkspaceEntry = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.issue_id, entry.issue_id);
+    }
+
+    #[test]
+    fn test_standalone_workspace_entry_serialization() {
+        let entry = TempWorkspaceEntry {
+            source_project_path: "/projects/test".to_string(),
+            issue_id: String::new(),
+            issue_display_number: 0,
+            issue_title: String::new(),
+            agent_name: "claude".to_string(),
+            action: "standalone".to_string(),
+            created_at: "2025-01-01T00:00:00Z".to_string(),
+            expires_at: "2025-01-01T12:00:00Z".to_string(),
+            worktree_ref: "HEAD".to_string(),
+            is_standalone: true,
+            workspace_id: "ws-uuid-5678".to_string(),
+            workspace_name: "My Experiment".to_string(),
+            workspace_description: "Testing new ideas".to_string(),
+        };
+
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(json.contains("isStandalone"));
+        assert!(json.contains("workspaceName"));
+
+        let deserialized: TempWorkspaceEntry = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.is_standalone);
+        assert_eq!(deserialized.workspace_name, "My Experiment");
+    }
+
+    #[test]
+    fn test_backwards_compatibility() {
+        // Test that old entries without standalone fields can still be deserialized
+        let old_json = r#"{
+            "sourceProjectPath": "/projects/test",
+            "issueId": "uuid-1234",
+            "issueDisplayNumber": 42,
+            "issueTitle": "Test Issue",
+            "agentName": "claude",
+            "action": "plan",
+            "createdAt": "2025-01-01T00:00:00Z",
+            "expiresAt": "2025-01-01T12:00:00Z",
+            "worktreeRef": "HEAD"
+        }"#;
+
+        let entry: TempWorkspaceEntry = serde_json::from_str(old_json).unwrap();
+        assert!(!entry.is_standalone);
+        assert!(entry.workspace_id.is_empty());
+        assert!(entry.workspace_name.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Add the ability to create workspaces that are not tied to a specific issue (standalone workspaces)
- Enable users to create temporary workspaces for experimentation without creating an issue first
- Support reusing existing standalone workspaces by name to avoid unnecessary worktree duplication
- Integrate standalone workspaces with the existing cleanup and management mechanisms

## Changes

### Proto (`proto/centy.proto`)
- Add `OpenStandaloneWorkspaceRequest` with `project_path`, `name`, `description`, `ttl_hours`, `agent_name` fields
- Add `OpenStandaloneWorkspaceResponse` with workspace details
- Add `OpenStandaloneWorkspaceVscode` and `OpenStandaloneWorkspaceTerminal` RPCs
- Update `TempWorkspace` message to include `is_standalone`, `workspace_id`, `workspace_name`, `workspace_description` fields

### Workspace Types (`src/workspace/types.rs`)
- Make `issue_id`, `issue_display_number`, `issue_title` optional with serde defaults for backwards compatibility
- Add `is_standalone`, `workspace_id`, `workspace_name`, `workspace_description` fields
- Bump schema version to 2
- Add tests for serialization and backwards compatibility

### Workspace Storage (`src/workspace/storage.rs`)
- Add `find_standalone_workspace()` function to find existing workspaces by ID or name
- Update `find_workspace_for_issue()` to skip standalone workspaces

### Workspace Creation (`src/workspace/create.rs`)
- Add `CreateStandaloneWorkspaceOptions` and `CreateStandaloneWorkspaceResult` structs
- Add `generate_standalone_workspace_path()` for unique path generation
- Add `create_standalone_workspace()` with name-based deduplication
- Add `copy_project_config_to_workspace()` for standalone workspaces (without issue data)

### Server (`src/server/mod.rs`)
- Implement `open_standalone_workspace_vscode()` RPC handler
- Implement `open_standalone_workspace_terminal()` RPC handler
- Update `list_temp_workspaces()` to include standalone workspace fields

## Test plan

- [x] All existing tests pass
- [x] Build completes successfully
- [x] Pre-commit hooks pass (cspell, clippy, formatting)
- [x] Pre-push hooks pass (all checks including tests)
- [ ] Manual testing: Create standalone workspace via VS Code
- [ ] Manual testing: Create standalone workspace via Terminal
- [ ] Manual testing: Verify workspace reuse by name
- [ ] Manual testing: Verify standalone workspaces appear in list
- [ ] Manual testing: Verify cleanup works for standalone workspaces

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)