### PR TITLE
feat: add custom lifecycle hooks system (#137)

### DIFF
--- a/proto/centy.proto
+++ b/proto/centy.proto
@@ -679,6 +679,7 @@ message Config {
   LlmConfig llm = 9;                        // LLM-related settings
   repeated LinkTypeDefinition custom_link_types = 10;  // Custom link types (in addition to built-in)
   string default_editor = 11;                // Default editor ID for this project (e.g., "vscode", "terminal", "zed")
+  repeated HookDefinition hooks = 12;                  // Lifecycle hooks
 }
 
 message CustomFieldDefinition {
@@ -694,6 +695,15 @@ message LlmConfig {
   optional bool update_status_on_start = 2;    // Update status to in-progress when LLM starts work (null = prompt user)
   bool allow_direct_edits = 3;        // Allow LLM to directly edit issue files
   WorkspaceMode default_workspace_mode = 4;  // Default workspace mode for agent operations
+}
+
+// Lifecycle hook definition (bash scripts to run before/after operations)
+message HookDefinition {
+  string pattern = 1;                   // Pattern like "pre:issue:create" or "*:*:delete"
+  string command = 2;                   // Bash command to execute
+  bool run_async = 3;                   // If true, run in background (post-hooks only)
+  uint64 timeout = 4;                   // Timeout in seconds (default: 30)
+  bool enabled = 5;                     // Whether hook is enabled (default: true)
 }
 
 // Custom link type definition (for custom relationship types)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,3 +1,4 @@
+use crate::hooks::HookDefinition;
 use crate::link::CustomLinkTypeDefinition;
 use crate::utils::get_centy_path;
 use serde::{Deserialize, Serialize};
@@ -109,6 +110,9 @@ pub struct CentyConfig {
     /// Overrides the user-level default. Empty means use user default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_editor: Option<String>,
+    /// Lifecycle hooks (bash scripts to run before/after operations)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub hooks: Vec<HookDefinition>,
 }
 
 impl CentyConfig {
@@ -135,6 +139,7 @@ impl Default for CentyConfig {
             llm: LlmConfig::default(),
             custom_link_types: Vec::new(),
             default_editor: None,
+            hooks: Vec::new(),
         }
     }
 }
@@ -254,6 +259,7 @@ mod tests {
         assert!(config.state_colors.is_empty());
         assert!(config.priority_colors.is_empty());
         assert!(config.custom_link_types.is_empty());
+        assert!(config.hooks.is_empty());
     }
 
     #[test]

--- a/src/hooks/config.rs
+++ b/src/hooks/config.rs
@@ -1,0 +1,320 @@
+use serde::{Deserialize, Serialize};
+
+use super::error::HookError;
+
+/// Default timeout for hooks in seconds
+fn default_timeout() -> u64 {
+    30
+}
+
+/// Default enabled state for hooks
+fn default_enabled() -> bool {
+    true
+}
+
+/// Hook definition from config.json
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HookDefinition {
+    /// Pattern like "pre:issue:create", "post:*:delete", "*:doc:*"
+    pub pattern: String,
+    /// Bash command to execute
+    pub command: String,
+    /// If true, run in background (post-hooks only)
+    #[serde(default, rename = "async")]
+    pub is_async: bool,
+    /// Timeout in seconds (default 30)
+    #[serde(default = "default_timeout")]
+    pub timeout: u64,
+    /// Whether hook is enabled (default true)
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+}
+
+/// Phase of hook execution
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Phase {
+    Pre,
+    Post,
+}
+
+impl Phase {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Phase::Pre => "pre",
+            Phase::Post => "post",
+        }
+    }
+}
+
+/// Item types that hooks can target
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookItemType {
+    Issue,
+    Doc,
+    Pr,
+    User,
+    Link,
+    Asset,
+}
+
+impl HookItemType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            HookItemType::Issue => "issue",
+            HookItemType::Doc => "doc",
+            HookItemType::Pr => "pr",
+            HookItemType::User => "user",
+            HookItemType::Link => "link",
+            HookItemType::Asset => "asset",
+        }
+    }
+}
+
+/// Operations that hooks can target
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookOperation {
+    Create,
+    Update,
+    Delete,
+    SoftDelete,
+    Restore,
+    Move,
+    Duplicate,
+}
+
+impl HookOperation {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            HookOperation::Create => "create",
+            HookOperation::Update => "update",
+            HookOperation::Delete => "delete",
+            HookOperation::SoftDelete => "soft-delete",
+            HookOperation::Restore => "restore",
+            HookOperation::Move => "move",
+            HookOperation::Duplicate => "duplicate",
+        }
+    }
+}
+
+/// A segment of a parsed pattern
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PatternSegment {
+    Exact(String),
+    Wildcard,
+}
+
+/// A parsed hook pattern (e.g., "pre:issue:create")
+#[derive(Debug, Clone)]
+pub struct ParsedPattern {
+    pub phase: PatternSegment,
+    pub item_type: PatternSegment,
+    pub operation: PatternSegment,
+}
+
+impl ParsedPattern {
+    /// Parse a pattern string like "pre:issue:create" or "*:*:delete"
+    pub fn parse(pattern: &str) -> Result<Self, HookError> {
+        let parts: Vec<&str> = pattern.split(':').collect();
+        if parts.len() != 3 {
+            return Err(HookError::InvalidPattern(format!(
+                "Pattern must have exactly 3 segments (phase:item_type:operation), got: '{pattern}'"
+            )));
+        }
+
+        let phase = Self::parse_segment(parts[0], &["pre", "post"])?;
+        let item_type =
+            Self::parse_segment(parts[1], &["issue", "doc", "pr", "user", "link", "asset"])?;
+        let operation = Self::parse_segment(
+            parts[2],
+            &[
+                "create",
+                "update",
+                "delete",
+                "soft-delete",
+                "restore",
+                "move",
+                "duplicate",
+            ],
+        )?;
+
+        Ok(ParsedPattern {
+            phase,
+            item_type,
+            operation,
+        })
+    }
+
+    fn parse_segment(value: &str, valid_values: &[&str]) -> Result<PatternSegment, HookError> {
+        if value == "*" {
+            return Ok(PatternSegment::Wildcard);
+        }
+        if valid_values.contains(&value) {
+            return Ok(PatternSegment::Exact(value.to_string()));
+        }
+        Err(HookError::InvalidPattern(format!(
+            "Invalid pattern value '{value}', expected one of: {}, or '*'",
+            valid_values.join(", ")
+        )))
+    }
+
+    /// Check if this pattern matches a given phase, item_type, and operation
+    pub fn matches(&self, phase: Phase, item_type: HookItemType, operation: HookOperation) -> bool {
+        Self::segment_matches(&self.phase, phase.as_str())
+            && Self::segment_matches(&self.item_type, item_type.as_str())
+            && Self::segment_matches(&self.operation, operation.as_str())
+    }
+
+    fn segment_matches(segment: &PatternSegment, value: &str) -> bool {
+        match segment {
+            PatternSegment::Wildcard => true,
+            PatternSegment::Exact(s) => s == value,
+        }
+    }
+
+    /// Count of non-wildcard segments (0-3). Higher = more specific.
+    pub fn specificity(&self) -> u8 {
+        let mut count = 0;
+        if self.phase != PatternSegment::Wildcard {
+            count += 1;
+        }
+        if self.item_type != PatternSegment::Wildcard {
+            count += 1;
+        }
+        if self.operation != PatternSegment::Wildcard {
+            count += 1;
+        }
+        count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_valid_pattern() {
+        let p = ParsedPattern::parse("pre:issue:create").unwrap();
+        assert_eq!(p.phase, PatternSegment::Exact("pre".to_string()));
+        assert_eq!(p.item_type, PatternSegment::Exact("issue".to_string()));
+        assert_eq!(p.operation, PatternSegment::Exact("create".to_string()));
+    }
+
+    #[test]
+    fn test_parse_wildcard_pattern() {
+        let p = ParsedPattern::parse("*:*:delete").unwrap();
+        assert_eq!(p.phase, PatternSegment::Wildcard);
+        assert_eq!(p.item_type, PatternSegment::Wildcard);
+        assert_eq!(p.operation, PatternSegment::Exact("delete".to_string()));
+    }
+
+    #[test]
+    fn test_parse_all_wildcards() {
+        let p = ParsedPattern::parse("*:*:*").unwrap();
+        assert_eq!(p.phase, PatternSegment::Wildcard);
+        assert_eq!(p.item_type, PatternSegment::Wildcard);
+        assert_eq!(p.operation, PatternSegment::Wildcard);
+    }
+
+    #[test]
+    fn test_parse_invalid_segment_count() {
+        let err = ParsedPattern::parse("pre:issue").unwrap_err();
+        assert!(matches!(err, HookError::InvalidPattern(_)));
+    }
+
+    #[test]
+    fn test_parse_invalid_phase() {
+        let err = ParsedPattern::parse("during:issue:create").unwrap_err();
+        assert!(matches!(err, HookError::InvalidPattern(_)));
+    }
+
+    #[test]
+    fn test_parse_invalid_item_type() {
+        let err = ParsedPattern::parse("pre:widget:create").unwrap_err();
+        assert!(matches!(err, HookError::InvalidPattern(_)));
+    }
+
+    #[test]
+    fn test_parse_invalid_operation() {
+        let err = ParsedPattern::parse("pre:issue:explode").unwrap_err();
+        assert!(matches!(err, HookError::InvalidPattern(_)));
+    }
+
+    #[test]
+    fn test_matches_exact() {
+        let p = ParsedPattern::parse("pre:issue:create").unwrap();
+        assert!(p.matches(Phase::Pre, HookItemType::Issue, HookOperation::Create));
+        assert!(!p.matches(Phase::Post, HookItemType::Issue, HookOperation::Create));
+        assert!(!p.matches(Phase::Pre, HookItemType::Doc, HookOperation::Create));
+        assert!(!p.matches(Phase::Pre, HookItemType::Issue, HookOperation::Delete));
+    }
+
+    #[test]
+    fn test_matches_wildcard_phase() {
+        let p = ParsedPattern::parse("*:issue:create").unwrap();
+        assert!(p.matches(Phase::Pre, HookItemType::Issue, HookOperation::Create));
+        assert!(p.matches(Phase::Post, HookItemType::Issue, HookOperation::Create));
+        assert!(!p.matches(Phase::Pre, HookItemType::Doc, HookOperation::Create));
+    }
+
+    #[test]
+    fn test_matches_wildcard_item_type() {
+        let p = ParsedPattern::parse("pre:*:create").unwrap();
+        assert!(p.matches(Phase::Pre, HookItemType::Issue, HookOperation::Create));
+        assert!(p.matches(Phase::Pre, HookItemType::Doc, HookOperation::Create));
+        assert!(p.matches(Phase::Pre, HookItemType::Pr, HookOperation::Create));
+        assert!(!p.matches(Phase::Post, HookItemType::Issue, HookOperation::Create));
+    }
+
+    #[test]
+    fn test_matches_all_wildcards() {
+        let p = ParsedPattern::parse("*:*:*").unwrap();
+        assert!(p.matches(Phase::Pre, HookItemType::Issue, HookOperation::Create));
+        assert!(p.matches(Phase::Post, HookItemType::Doc, HookOperation::Delete));
+    }
+
+    #[test]
+    fn test_specificity() {
+        assert_eq!(ParsedPattern::parse("*:*:*").unwrap().specificity(), 0);
+        assert_eq!(ParsedPattern::parse("pre:*:*").unwrap().specificity(), 1);
+        assert_eq!(
+            ParsedPattern::parse("pre:issue:*").unwrap().specificity(),
+            2
+        );
+        assert_eq!(
+            ParsedPattern::parse("pre:issue:create")
+                .unwrap()
+                .specificity(),
+            3
+        );
+        assert_eq!(ParsedPattern::parse("*:*:delete").unwrap().specificity(), 1);
+        assert_eq!(
+            ParsedPattern::parse("*:issue:delete")
+                .unwrap()
+                .specificity(),
+            2
+        );
+    }
+
+    #[test]
+    fn test_soft_delete_pattern() {
+        let p = ParsedPattern::parse("post:issue:soft-delete").unwrap();
+        assert!(p.matches(Phase::Post, HookItemType::Issue, HookOperation::SoftDelete));
+        assert!(!p.matches(Phase::Post, HookItemType::Issue, HookOperation::Delete));
+    }
+
+    #[test]
+    fn test_all_item_types() {
+        let p = ParsedPattern::parse("pre:asset:create").unwrap();
+        assert!(p.matches(Phase::Pre, HookItemType::Asset, HookOperation::Create));
+
+        let p = ParsedPattern::parse("pre:link:create").unwrap();
+        assert!(p.matches(Phase::Pre, HookItemType::Link, HookOperation::Create));
+
+        let p = ParsedPattern::parse("pre:user:create").unwrap();
+        assert!(p.matches(Phase::Pre, HookItemType::User, HookOperation::Create));
+
+        let p = ParsedPattern::parse("pre:pr:create").unwrap();
+        assert!(p.matches(Phase::Pre, HookItemType::Pr, HookOperation::Create));
+    }
+}

--- a/src/hooks/context.rs
+++ b/src/hooks/context.rs
@@ -1,0 +1,123 @@
+use serde::Serialize;
+use std::collections::HashMap;
+
+use super::config::{HookItemType, HookOperation, Phase};
+
+/// Context passed to hook scripts via env vars and stdin JSON
+#[derive(Debug, Clone, Serialize)]
+pub struct HookContext {
+    pub phase: String,
+    pub item_type: String,
+    pub operation: String,
+    pub project_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub item_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_data: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub success: Option<bool>,
+}
+
+impl HookContext {
+    pub fn new(
+        phase: Phase,
+        item_type: HookItemType,
+        operation: HookOperation,
+        project_path: &str,
+        item_id: Option<&str>,
+        request_data: Option<serde_json::Value>,
+        success: Option<bool>,
+    ) -> Self {
+        Self {
+            phase: phase.as_str().to_string(),
+            item_type: item_type.as_str().to_string(),
+            operation: operation.as_str().to_string(),
+            project_path: project_path.to_string(),
+            item_id: item_id.map(String::from),
+            request_data,
+            success,
+        }
+    }
+
+    /// Convert to environment variables for the hook process
+    pub fn to_env_vars(&self) -> HashMap<String, String> {
+        let mut vars = HashMap::new();
+        vars.insert("CENTY_PHASE".to_string(), self.phase.clone());
+        vars.insert("CENTY_ITEM_TYPE".to_string(), self.item_type.clone());
+        vars.insert("CENTY_OPERATION".to_string(), self.operation.clone());
+        vars.insert("CENTY_PROJECT_PATH".to_string(), self.project_path.clone());
+        if let Some(ref id) = self.item_id {
+            vars.insert("CENTY_ITEM_ID".to_string(), id.clone());
+        }
+        vars
+    }
+
+    /// Convert to JSON string for stdin piping
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_context_env_vars() {
+        let ctx = HookContext::new(
+            Phase::Pre,
+            HookItemType::Issue,
+            HookOperation::Create,
+            "/tmp/project",
+            Some("issue-123"),
+            None,
+            None,
+        );
+
+        let vars = ctx.to_env_vars();
+        assert_eq!(vars.get("CENTY_PHASE").unwrap(), "pre");
+        assert_eq!(vars.get("CENTY_ITEM_TYPE").unwrap(), "issue");
+        assert_eq!(vars.get("CENTY_OPERATION").unwrap(), "create");
+        assert_eq!(vars.get("CENTY_PROJECT_PATH").unwrap(), "/tmp/project");
+        assert_eq!(vars.get("CENTY_ITEM_ID").unwrap(), "issue-123");
+    }
+
+    #[test]
+    fn test_context_env_vars_no_item_id() {
+        let ctx = HookContext::new(
+            Phase::Pre,
+            HookItemType::Doc,
+            HookOperation::Create,
+            "/tmp/project",
+            None,
+            None,
+            None,
+        );
+
+        let vars = ctx.to_env_vars();
+        assert!(!vars.contains_key("CENTY_ITEM_ID"));
+    }
+
+    #[test]
+    fn test_context_to_json() {
+        let ctx = HookContext::new(
+            Phase::Post,
+            HookItemType::Issue,
+            HookOperation::Create,
+            "/tmp/project",
+            Some("issue-123"),
+            Some(serde_json::json!({"title": "Test"})),
+            Some(true),
+        );
+
+        let json = ctx.to_json().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["phase"], "post");
+        assert_eq!(parsed["item_type"], "issue");
+        assert_eq!(parsed["operation"], "create");
+        assert_eq!(parsed["project_path"], "/tmp/project");
+        assert_eq!(parsed["item_id"], "issue-123");
+        assert_eq!(parsed["request_data"]["title"], "Test");
+        assert_eq!(parsed["success"], true);
+    }
+}

--- a/src/hooks/error.rs
+++ b/src/hooks/error.rs
@@ -1,0 +1,26 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum HookError {
+    #[error("Pre-hook '{pattern}' failed with exit code {exit_code}: {stderr}")]
+    PreHookFailed {
+        pattern: String,
+        exit_code: i32,
+        stderr: String,
+    },
+
+    #[error("Hook '{pattern}' timed out after {timeout_secs}s")]
+    Timeout { pattern: String, timeout_secs: u64 },
+
+    #[error("Hook execution error: {0}")]
+    ExecutionError(String),
+
+    #[error("Invalid hook pattern: {0}")]
+    InvalidPattern(String),
+
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error("JSON error: {0}")]
+    JsonError(#[from] serde_json::Error),
+}

--- a/src/hooks/executor.rs
+++ b/src/hooks/executor.rs
@@ -1,0 +1,83 @@
+use std::path::Path;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::process::Command;
+
+use super::context::HookContext;
+use super::error::HookError;
+
+/// Result of executing a hook command
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct HookExecResult {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// Execute a single hook command
+pub async fn execute_hook(
+    command: &str,
+    context: &HookContext,
+    project_path: &Path,
+    timeout_secs: u64,
+    pattern: &str,
+) -> Result<HookExecResult, HookError> {
+    let env_vars = context.to_env_vars();
+    let json_input = context.to_json()?;
+
+    let mut child = Command::new("bash")
+        .arg("-c")
+        .arg(command)
+        .current_dir(project_path.join(".centy"))
+        .envs(env_vars)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()?;
+
+    // Write JSON to stdin
+    if let Some(mut stdin) = child.stdin.take() {
+        // Ignore write errors - the process may have exited
+        let _ = stdin.write_all(json_input.as_bytes()).await;
+        drop(stdin);
+    }
+
+    // Take stdout/stderr handles before waiting
+    let mut stdout_handle = child.stdout.take();
+    let mut stderr_handle = child.stderr.take();
+
+    // Wait with timeout
+    let wait_result =
+        tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), child.wait()).await;
+
+    match wait_result {
+        Ok(Ok(status)) => {
+            // Read stdout and stderr
+            let mut stdout_buf = Vec::new();
+            let mut stderr_buf = Vec::new();
+            if let Some(ref mut stdout) = stdout_handle {
+                let _ = stdout.read_to_end(&mut stdout_buf).await;
+            }
+            if let Some(ref mut stderr) = stderr_handle {
+                let _ = stderr.read_to_end(&mut stderr_buf).await;
+            }
+
+            Ok(HookExecResult {
+                exit_code: status.code().unwrap_or(-1),
+                stdout: String::from_utf8_lossy(&stdout_buf).to_string(),
+                stderr: String::from_utf8_lossy(&stderr_buf).to_string(),
+            })
+        }
+        Ok(Err(e)) => Err(HookError::ExecutionError(format!(
+            "Failed to execute hook command: {e}"
+        ))),
+        Err(_) => {
+            // Timeout - try to kill the process
+            let _ = child.kill().await;
+            Err(HookError::Timeout {
+                pattern: pattern.to_string(),
+                timeout_secs,
+            })
+        }
+    }
+}

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1,0 +1,11 @@
+pub mod config;
+pub mod context;
+pub mod error;
+pub mod executor;
+pub mod runner;
+
+pub use config::{HookDefinition, HookItemType, HookOperation, Phase};
+pub use context::HookContext;
+#[allow(unused_imports)]
+pub use error::HookError;
+pub use runner::{run_post_hooks, run_pre_hooks};

--- a/src/hooks/runner.rs
+++ b/src/hooks/runner.rs
@@ -1,0 +1,301 @@
+use std::path::Path;
+use tracing::{debug, warn};
+
+use super::config::{HookDefinition, HookItemType, HookOperation, ParsedPattern, Phase};
+use super::context::HookContext;
+use super::error::HookError;
+use super::executor::execute_hook;
+
+/// Load hooks configuration from the project's config.json.
+/// Returns an empty vec if no config exists or no hooks are configured.
+pub async fn load_hooks_config(project_path: &Path) -> Vec<HookDefinition> {
+    match crate::config::read_config(project_path).await {
+        Ok(Some(config)) => config.hooks,
+        _ => Vec::new(),
+    }
+}
+
+/// Find matching hooks for the given phase, item_type, and operation.
+/// Returns enabled hooks sorted by specificity descending (most-specific-first).
+pub fn find_matching_hooks(
+    hooks: &[HookDefinition],
+    phase: Phase,
+    item_type: HookItemType,
+    operation: HookOperation,
+) -> Vec<&HookDefinition> {
+    let mut matching: Vec<(&HookDefinition, u8)> = hooks
+        .iter()
+        .filter(|h| h.enabled)
+        .filter_map(|h| {
+            ParsedPattern::parse(&h.pattern)
+                .ok()
+                .filter(|p| p.matches(phase, item_type, operation))
+                .map(|p| (h, p.specificity()))
+        })
+        .collect();
+
+    // Sort by specificity descending (most-specific-first)
+    matching.sort_by(|a, b| b.1.cmp(&a.1));
+    matching.into_iter().map(|(h, _)| h).collect()
+}
+
+/// Run pre-hooks for the given item_type and operation.
+/// Pre-hooks run synchronously; the first non-zero exit code aborts with an error.
+pub async fn run_pre_hooks(
+    project_path: &Path,
+    item_type: HookItemType,
+    operation: HookOperation,
+    context: &HookContext,
+) -> Result<(), HookError> {
+    let hooks = load_hooks_config(project_path).await;
+    let matching = find_matching_hooks(&hooks, Phase::Pre, item_type, operation);
+
+    if matching.is_empty() {
+        return Ok(());
+    }
+
+    debug!(
+        "Running {} pre-hooks for {}:{}",
+        matching.len(),
+        item_type.as_str(),
+        operation.as_str()
+    );
+
+    for hook in matching {
+        let result = execute_hook(
+            &hook.command,
+            context,
+            project_path,
+            hook.timeout,
+            &hook.pattern,
+        )
+        .await?;
+
+        if result.exit_code != 0 {
+            return Err(HookError::PreHookFailed {
+                pattern: hook.pattern.clone(),
+                exit_code: result.exit_code,
+                stderr: result.stderr,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Run post-hooks for the given item_type and operation.
+/// Synchronous post-hooks run inline (failures logged as warnings).
+/// Async post-hooks are spawned in background (failures logged as debug).
+pub async fn run_post_hooks(
+    project_path: &Path,
+    item_type: HookItemType,
+    operation: HookOperation,
+    context: &HookContext,
+) {
+    let hooks = load_hooks_config(project_path).await;
+    let matching = find_matching_hooks(&hooks, Phase::Post, item_type, operation);
+
+    if matching.is_empty() {
+        return;
+    }
+
+    debug!(
+        "Running {} post-hooks for {}:{}",
+        matching.len(),
+        item_type.as_str(),
+        operation.as_str()
+    );
+
+    for hook in matching {
+        if hook.is_async {
+            // Spawn async hooks in background
+            let command = hook.command.clone();
+            let context = context.clone();
+            let path = project_path.to_path_buf();
+            let timeout = hook.timeout;
+            let pattern = hook.pattern.clone();
+            tokio::spawn(async move {
+                match execute_hook(&command, &context, &path, timeout, &pattern).await {
+                    Ok(result) if result.exit_code != 0 => {
+                        debug!(
+                            "Async post-hook '{}' exited with code {}: {}",
+                            pattern, result.exit_code, result.stderr
+                        );
+                    }
+                    Err(e) => {
+                        debug!("Async post-hook '{}' failed: {}", pattern, e);
+                    }
+                    _ => {}
+                }
+            });
+        } else {
+            // Run synchronous post-hooks inline
+            match execute_hook(
+                &hook.command,
+                context,
+                project_path,
+                hook.timeout,
+                &hook.pattern,
+            )
+            .await
+            {
+                Ok(result) if result.exit_code != 0 => {
+                    warn!(
+                        "Post-hook '{}' exited with code {}: {}",
+                        hook.pattern, result.exit_code, result.stderr
+                    );
+                }
+                Err(e) => {
+                    warn!("Post-hook '{}' failed: {}", hook.pattern, e);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_matching_hooks_empty() {
+        let hooks: Vec<HookDefinition> = vec![];
+        let result = find_matching_hooks(
+            &hooks,
+            Phase::Pre,
+            HookItemType::Issue,
+            HookOperation::Create,
+        );
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_find_matching_hooks_exact_match() {
+        let hooks = vec![HookDefinition {
+            pattern: "pre:issue:create".to_string(),
+            command: "echo test".to_string(),
+            is_async: false,
+            timeout: 30,
+            enabled: true,
+        }];
+        let result = find_matching_hooks(
+            &hooks,
+            Phase::Pre,
+            HookItemType::Issue,
+            HookOperation::Create,
+        );
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_find_matching_hooks_no_match() {
+        let hooks = vec![HookDefinition {
+            pattern: "pre:issue:create".to_string(),
+            command: "echo test".to_string(),
+            is_async: false,
+            timeout: 30,
+            enabled: true,
+        }];
+        let result =
+            find_matching_hooks(&hooks, Phase::Pre, HookItemType::Doc, HookOperation::Create);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_find_matching_hooks_disabled_skipped() {
+        let hooks = vec![HookDefinition {
+            pattern: "pre:issue:create".to_string(),
+            command: "echo test".to_string(),
+            is_async: false,
+            timeout: 30,
+            enabled: false,
+        }];
+        let result = find_matching_hooks(
+            &hooks,
+            Phase::Pre,
+            HookItemType::Issue,
+            HookOperation::Create,
+        );
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_find_matching_hooks_specificity_order() {
+        let hooks = vec![
+            HookDefinition {
+                pattern: "*:*:*".to_string(),
+                command: "echo catch-all".to_string(),
+                is_async: false,
+                timeout: 30,
+                enabled: true,
+            },
+            HookDefinition {
+                pattern: "pre:issue:create".to_string(),
+                command: "echo specific".to_string(),
+                is_async: false,
+                timeout: 30,
+                enabled: true,
+            },
+            HookDefinition {
+                pattern: "pre:*:create".to_string(),
+                command: "echo mid".to_string(),
+                is_async: false,
+                timeout: 30,
+                enabled: true,
+            },
+        ];
+        let result = find_matching_hooks(
+            &hooks,
+            Phase::Pre,
+            HookItemType::Issue,
+            HookOperation::Create,
+        );
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].command, "echo specific"); // specificity 3
+        assert_eq!(result[1].command, "echo mid"); // specificity 2
+        assert_eq!(result[2].command, "echo catch-all"); // specificity 0
+    }
+
+    #[test]
+    fn test_find_matching_hooks_wildcard_matches_multiple() {
+        let hooks = vec![HookDefinition {
+            pattern: "*:*:delete".to_string(),
+            command: "echo delete".to_string(),
+            is_async: false,
+            timeout: 30,
+            enabled: true,
+        }];
+        // Should match for any item type with delete operation
+        assert_eq!(
+            find_matching_hooks(
+                &hooks,
+                Phase::Pre,
+                HookItemType::Issue,
+                HookOperation::Delete
+            )
+            .len(),
+            1
+        );
+        assert_eq!(
+            find_matching_hooks(
+                &hooks,
+                Phase::Post,
+                HookItemType::Doc,
+                HookOperation::Delete
+            )
+            .len(),
+            1
+        );
+        assert_eq!(
+            find_matching_hooks(
+                &hooks,
+                Phase::Pre,
+                HookItemType::Issue,
+                HookOperation::Create
+            )
+            .len(),
+            0
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 
 pub mod common;
 pub mod config;
+pub mod hooks;
 pub mod item;
 pub mod link;
 pub mod logging;
@@ -39,6 +40,7 @@ pub mod workspace;
 // Re-export commonly used types
 pub use common::CommonMetadata;
 pub use config::{CentyConfig, CustomFieldDefinition};
+pub use hooks::{HookContext, HookDefinition, HookError};
 pub use item::entities::doc::{
     create_doc, delete_doc, get_doc, list_docs, update_doc, CreateDocOptions, CreateDocResult,
     DeleteDocResult, Doc, DocError, DocMetadata, UpdateDocOptions, UpdateDocResult,

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod common;
 mod config;
 mod cors;
 mod grpc_logging;
+mod hooks;
 mod item;
 mod link;
 mod logging;

--- a/tests/hooks_test.rs
+++ b/tests/hooks_test.rs
@@ -1,0 +1,547 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use centy_daemon::config::{write_config, CentyConfig};
+use centy_daemon::hooks::config::{
+    HookDefinition, HookItemType, HookOperation, ParsedPattern, Phase,
+};
+use centy_daemon::hooks::context::HookContext;
+use centy_daemon::hooks::executor::execute_hook;
+use centy_daemon::hooks::runner::{find_matching_hooks, run_post_hooks, run_pre_hooks};
+use common::{create_test_dir, init_centy_project};
+
+#[tokio::test]
+async fn test_pre_hook_blocks_on_exit_1() {
+    let temp_dir = create_test_dir();
+    init_centy_project(temp_dir.path()).await;
+
+    // Write config with a pre-hook that exits 1
+    let mut config = CentyConfig::default();
+    config.hooks.push(HookDefinition {
+        pattern: "pre:issue:create".to_string(),
+        command: "exit 1".to_string(),
+        is_async: false,
+        timeout: 30,
+        enabled: true,
+    });
+    write_config(temp_dir.path(), &config).await.unwrap();
+
+    let context = HookContext::new(
+        Phase::Pre,
+        HookItemType::Issue,
+        HookOperation::Create,
+        &temp_dir.path().to_string_lossy(),
+        None,
+        None,
+        None,
+    );
+
+    let result = run_pre_hooks(
+        temp_dir.path(),
+        HookItemType::Issue,
+        HookOperation::Create,
+        &context,
+    )
+    .await;
+
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("pre:issue:create"),
+        "Error should mention the pattern: {err_msg}"
+    );
+}
+
+#[tokio::test]
+async fn test_pre_hook_passes_on_exit_0() {
+    let temp_dir = create_test_dir();
+    init_centy_project(temp_dir.path()).await;
+
+    let mut config = CentyConfig::default();
+    config.hooks.push(HookDefinition {
+        pattern: "pre:issue:create".to_string(),
+        command: "exit 0".to_string(),
+        is_async: false,
+        timeout: 30,
+        enabled: true,
+    });
+    write_config(temp_dir.path(), &config).await.unwrap();
+
+    let context = HookContext::new(
+        Phase::Pre,
+        HookItemType::Issue,
+        HookOperation::Create,
+        &temp_dir.path().to_string_lossy(),
+        None,
+        None,
+        None,
+    );
+
+    let result = run_pre_hooks(
+        temp_dir.path(),
+        HookItemType::Issue,
+        HookOperation::Create,
+        &context,
+    )
+    .await;
+
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_hook_receives_env_vars() {
+    let temp_dir = create_test_dir();
+    init_centy_project(temp_dir.path()).await;
+
+    let marker = temp_dir.path().join("env_marker.txt");
+    let command = format!(
+        "echo \"$CENTY_PHASE $CENTY_ITEM_TYPE $CENTY_OPERATION $CENTY_ITEM_ID\" > {}",
+        marker.to_string_lossy()
+    );
+
+    let mut config = CentyConfig::default();
+    config.hooks.push(HookDefinition {
+        pattern: "pre:issue:update".to_string(),
+        command,
+        is_async: false,
+        timeout: 30,
+        enabled: true,
+    });
+    write_config(temp_dir.path(), &config).await.unwrap();
+
+    let context = HookContext::new(
+        Phase::Pre,
+        HookItemType::Issue,
+        HookOperation::Update,
+        &temp_dir.path().to_string_lossy(),
+        Some("issue-abc"),
+        None,
+        None,
+    );
+
+    let result = run_pre_hooks(
+        temp_dir.path(),
+        HookItemType::Issue,
+        HookOperation::Update,
+        &context,
+    )
+    .await;
+
+    assert!(result.is_ok());
+
+    let content = tokio::fs::read_to_string(&marker).await.unwrap();
+    assert_eq!(content.trim(), "pre issue update issue-abc");
+}
+
+#[tokio::test]
+async fn test_hook_receives_stdin_json() {
+    let temp_dir = create_test_dir();
+    init_centy_project(temp_dir.path()).await;
+
+    let marker = temp_dir.path().join("stdin_marker.txt");
+    let command = format!("cat > {}", marker.to_string_lossy());
+
+    let mut config = CentyConfig::default();
+    config.hooks.push(HookDefinition {
+        pattern: "pre:issue:create".to_string(),
+        command,
+        is_async: false,
+        timeout: 30,
+        enabled: true,
+    });
+    write_config(temp_dir.path(), &config).await.unwrap();
+
+    let request_data = serde_json::json!({"title": "Test Issue"});
+    let context = HookContext::new(
+        Phase::Pre,
+        HookItemType::Issue,
+        HookOperation::Create,
+        &temp_dir.path().to_string_lossy(),
+        None,
+        Some(request_data),
+        None,
+    );
+
+    let result = run_pre_hooks(
+        temp_dir.path(),
+        HookItemType::Issue,
+        HookOperation::Create,
+        &context,
+    )
+    .await;
+
+    assert!(result.is_ok());
+
+    let content = tokio::fs::read_to_string(&marker).await.unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(parsed["phase"], "pre");
+    assert_eq!(parsed["item_type"], "issue");
+    assert_eq!(parsed["operation"], "create");
+    assert_eq!(parsed["request_data"]["title"], "Test Issue");
+}
+
+#[tokio::test]
+async fn test_hook_timeout() {
+    let temp_dir = create_test_dir();
+    init_centy_project(temp_dir.path()).await;
+
+    let context = HookContext::new(
+        Phase::Pre,
+        HookItemType::Issue,
+        HookOperation::Create,
+        &temp_dir.path().to_string_lossy(),
+        None,
+        None,
+        None,
+    );
+
+    let result = execute_hook(
+        "sleep 60",
+        &context,
+        temp_dir.path(),
+        1, // 1 second timeout
+        "pre:issue:create",
+    )
+    .await;
+
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("timed out"),
+        "Error should mention timeout: {err_msg}"
+    );
+}
+
+#[tokio::test]
+async fn test_wildcard_matching_across_item_types() {
+    let hooks = vec![HookDefinition {
+        pattern: "*:*:delete".to_string(),
+        command: "echo deleted".to_string(),
+        is_async: false,
+        timeout: 30,
+        enabled: true,
+    }];
+
+    // Should match any item type with delete operation
+    assert_eq!(
+        find_matching_hooks(
+            &hooks,
+            Phase::Pre,
+            HookItemType::Issue,
+            HookOperation::Delete
+        )
+        .len(),
+        1
+    );
+    assert_eq!(
+        find_matching_hooks(
+            &hooks,
+            Phase::Post,
+            HookItemType::Doc,
+            HookOperation::Delete
+        )
+        .len(),
+        1
+    );
+    assert_eq!(
+        find_matching_hooks(&hooks, Phase::Pre, HookItemType::Pr, HookOperation::Delete).len(),
+        1
+    );
+    assert_eq!(
+        find_matching_hooks(
+            &hooks,
+            Phase::Post,
+            HookItemType::User,
+            HookOperation::Delete
+        )
+        .len(),
+        1
+    );
+    // Should NOT match create
+    assert_eq!(
+        find_matching_hooks(
+            &hooks,
+            Phase::Pre,
+            HookItemType::Issue,
+            HookOperation::Create
+        )
+        .len(),
+        0
+    );
+}
+
+#[tokio::test]
+async fn test_specificity_ordering_verified_by_file() {
+    let temp_dir = create_test_dir();
+    init_centy_project(temp_dir.path()).await;
+
+    let marker = temp_dir.path().join("order_marker.txt");
+    let marker_path = marker.to_string_lossy().to_string();
+
+    let mut config = CentyConfig::default();
+    // Add hooks in reverse specificity order
+    config.hooks.push(HookDefinition {
+        pattern: "*:*:*".to_string(),
+        command: format!("echo catch-all >> {marker_path}"),
+        is_async: false,
+        timeout: 30,
+        enabled: true,
+    });
+    config.hooks.push(HookDefinition {
+        pattern: "pre:issue:create".to_string(),
+        command: format!("echo specific >> {marker_path}"),
+        is_async: false,
+        timeout: 30,
+        enabled: true,
+    });
+    config.hooks.push(HookDefinition {
+        pattern: "pre:*:create".to_string(),
+        command: format!("echo mid >> {marker_path}"),
+        is_async: false,
+        timeout: 30,
+        enabled: true,
+    });
+    write_config(temp_dir.path(), &config).await.unwrap();
+
+    let context = HookContext::new(
+        Phase::Pre,
+        HookItemType::Issue,
+        HookOperation::Create,
+        &temp_dir.path().to_string_lossy(),
+        None,
+        None,
+        None,
+    );
+
+    let result = run_pre_hooks(
+        temp_dir.path(),
+        HookItemType::Issue,
+        HookOperation::Create,
+        &context,
+    )
+    .await;
+
+    assert!(result.is_ok());
+
+    let content = tokio::fs::read_to_string(&marker).await.unwrap();
+    let lines: Vec<&str> = content.trim().lines().collect();
+    assert_eq!(lines.len(), 3);
+    assert_eq!(lines[0], "specific"); // Most specific first (specificity 3)
+    assert_eq!(lines[1], "mid"); // Mid specificity (specificity 2)
+    assert_eq!(lines[2], "catch-all"); // Least specific (specificity 0)
+}
+
+#[tokio::test]
+async fn test_disabled_hooks_are_skipped() {
+    let temp_dir = create_test_dir();
+    init_centy_project(temp_dir.path()).await;
+
+    let marker = temp_dir.path().join("disabled_marker.txt");
+
+    let mut config = CentyConfig::default();
+    config.hooks.push(HookDefinition {
+        pattern: "pre:issue:create".to_string(),
+        command: format!("echo ran > {}", marker.to_string_lossy()),
+        is_async: false,
+        timeout: 30,
+        enabled: false, // Disabled
+    });
+    write_config(temp_dir.path(), &config).await.unwrap();
+
+    let context = HookContext::new(
+        Phase::Pre,
+        HookItemType::Issue,
+        HookOperation::Create,
+        &temp_dir.path().to_string_lossy(),
+        None,
+        None,
+        None,
+    );
+
+    let result = run_pre_hooks(
+        temp_dir.path(),
+        HookItemType::Issue,
+        HookOperation::Create,
+        &context,
+    )
+    .await;
+
+    assert!(result.is_ok());
+    assert!(!marker.exists(), "Disabled hook should not have run");
+}
+
+#[tokio::test]
+async fn test_no_hooks_configured_is_noop() {
+    let temp_dir = create_test_dir();
+    init_centy_project(temp_dir.path()).await;
+
+    // Write config with no hooks
+    let config = CentyConfig::default();
+    write_config(temp_dir.path(), &config).await.unwrap();
+
+    let context = HookContext::new(
+        Phase::Pre,
+        HookItemType::Issue,
+        HookOperation::Create,
+        &temp_dir.path().to_string_lossy(),
+        None,
+        None,
+        None,
+    );
+
+    let result = run_pre_hooks(
+        temp_dir.path(),
+        HookItemType::Issue,
+        HookOperation::Create,
+        &context,
+    )
+    .await;
+
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_post_hooks_run_after_success() {
+    let temp_dir = create_test_dir();
+    init_centy_project(temp_dir.path()).await;
+
+    let marker = temp_dir.path().join("post_marker.txt");
+
+    let mut config = CentyConfig::default();
+    config.hooks.push(HookDefinition {
+        pattern: "post:issue:create".to_string(),
+        command: format!("echo post_ran > {}", marker.to_string_lossy()),
+        is_async: false,
+        timeout: 30,
+        enabled: true,
+    });
+    write_config(temp_dir.path(), &config).await.unwrap();
+
+    let context = HookContext::new(
+        Phase::Post,
+        HookItemType::Issue,
+        HookOperation::Create,
+        &temp_dir.path().to_string_lossy(),
+        Some("issue-123"),
+        None,
+        Some(true),
+    );
+
+    run_post_hooks(
+        temp_dir.path(),
+        HookItemType::Issue,
+        HookOperation::Create,
+        &context,
+    )
+    .await;
+
+    let content = tokio::fs::read_to_string(&marker).await.unwrap();
+    assert_eq!(content.trim(), "post_ran");
+}
+
+#[test]
+fn test_pattern_parse_all_operations() {
+    // Verify all operations parse correctly
+    let ops = [
+        "create",
+        "update",
+        "delete",
+        "soft-delete",
+        "restore",
+        "move",
+        "duplicate",
+    ];
+    for op in ops {
+        let pattern = format!("pre:issue:{op}");
+        assert!(
+            ParsedPattern::parse(&pattern).is_ok(),
+            "Failed to parse pattern: {pattern}"
+        );
+    }
+}
+
+#[test]
+fn test_pattern_parse_all_item_types() {
+    let types = ["issue", "doc", "pr", "user", "link", "asset"];
+    for item_type in types {
+        let pattern = format!("pre:{item_type}:create");
+        assert!(
+            ParsedPattern::parse(&pattern).is_ok(),
+            "Failed to parse pattern: {pattern}"
+        );
+    }
+}
+
+#[test]
+fn test_hook_definition_serialization() {
+    let hook = HookDefinition {
+        pattern: "pre:issue:create".to_string(),
+        command: "echo test".to_string(),
+        is_async: false,
+        timeout: 30,
+        enabled: true,
+    };
+
+    let json = serde_json::to_string(&hook).unwrap();
+    let deserialized: HookDefinition = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(deserialized.pattern, "pre:issue:create");
+    assert_eq!(deserialized.command, "echo test");
+    assert!(!deserialized.is_async);
+    assert_eq!(deserialized.timeout, 30);
+    assert!(deserialized.enabled);
+}
+
+#[test]
+fn test_hook_definition_deserialization_defaults() {
+    // Test that defaults work when fields are omitted
+    let json = r#"{"pattern": "pre:issue:create", "command": "echo test"}"#;
+    let hook: HookDefinition = serde_json::from_str(json).unwrap();
+
+    assert_eq!(hook.pattern, "pre:issue:create");
+    assert_eq!(hook.command, "echo test");
+    assert!(!hook.is_async);
+    assert_eq!(hook.timeout, 30); // default
+    assert!(hook.enabled); // default
+}
+
+#[tokio::test]
+async fn test_config_with_hooks_roundtrip() {
+    let temp_dir = create_test_dir();
+    init_centy_project(temp_dir.path()).await;
+
+    let mut config = CentyConfig::default();
+    config.hooks.push(HookDefinition {
+        pattern: "pre:issue:create".to_string(),
+        command: "echo before".to_string(),
+        is_async: false,
+        timeout: 10,
+        enabled: true,
+    });
+    config.hooks.push(HookDefinition {
+        pattern: "post:*:*".to_string(),
+        command: "echo after".to_string(),
+        is_async: true,
+        timeout: 60,
+        enabled: false,
+    });
+
+    write_config(temp_dir.path(), &config).await.unwrap();
+
+    let loaded = centy_daemon::config::read_config(temp_dir.path())
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(loaded.hooks.len(), 2);
+    assert_eq!(loaded.hooks[0].pattern, "pre:issue:create");
+    assert_eq!(loaded.hooks[0].command, "echo before");
+    assert!(!loaded.hooks[0].is_async);
+    assert_eq!(loaded.hooks[0].timeout, 10);
+    assert!(loaded.hooks[0].enabled);
+
+    assert_eq!(loaded.hooks[1].pattern, "post:*:*");
+    assert!(loaded.hooks[1].is_async);
+    assert!(!loaded.hooks[1].enabled);
+}


### PR DESCRIPTION
## Summary

- Adds a hooks system that lets users configure bash scripts to run before/after any item operation (create, update, delete, soft-delete, restore, move, duplicate)
- Hooks are configured in `.centy/config.json` with pattern matching (`phase:item_type:operation`), wildcard support (`*:*:delete`), and specificity-based execution ordering
- Pre-hooks block operations on non-zero exit; post-hooks run inline (sync) or are spawned in background (async), with failures logged as warnings

## Details

**New module: `src/hooks/`** with 6 files:
- `config.rs` — `HookDefinition`, `Phase`, `HookItemType`, `HookOperation`, `ParsedPattern` with pattern parsing, matching, and specificity scoring
- `context.rs` — `HookContext` providing env vars (`CENTY_*`) and JSON stdin to hook commands
- `executor.rs` — Spawns `bash -c` with env vars, stdin JSON, configurable timeout, cwd set to `.centy/`
- `runner.rs` — Orchestrates hook loading, matching, and execution (pre-hooks synchronous/blocking, post-hooks sync or async)
- `error.rs` — `HookError` enum (PreHookFailed, Timeout, ExecutionError, InvalidPattern, IoError, JsonError)
- `mod.rs` — Module root with re-exports

**Modified 28 mutation handlers** in `src/server/mod.rs` with `maybe_run_pre_hooks` / `maybe_run_post_hooks` helpers covering: Issue, Doc, PR, User, Link, and Asset operations.

**Proto**: Added `HookDefinition` message and `hooks` field on `Config` message.

**Config**: Added `hooks: Vec<HookDefinition>` to `CentyConfig` with serde support and validation.

## Test plan

- [x] 23 unit tests (config parsing, pattern matching, specificity, context env vars/JSON, runner filtering)
- [x] 15 integration tests (pre-hook blocking, env vars, stdin JSON, timeout, wildcard matching, specificity ordering via file append, disabled hooks, no-hooks noop, post-hooks, serialization roundtrip)
- [x] All existing tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)