### PR TITLE
feat: auto-add hooks section to config.json for existing projects (#157)

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -160,10 +160,7 @@ pub async fn read_config(project_path: &Path) -> Result<Option<CentyConfig>, Con
     // Normalize: if the raw JSON is missing the "hooks" key, write back
     // to ensure all projects have the hooks section in config.json.
     let raw: serde_json::Value = serde_json::from_str(&content)?;
-    if !raw
-        .as_object()
-        .is_some_and(|o| o.contains_key("hooks"))
-    {
+    if !raw.as_object().is_some_and(|o| o.contains_key("hooks")) {
         let normalized = serde_json::to_string_pretty(&config)?;
         fs::write(&config_path, normalized).await?;
     }


### PR DESCRIPTION
## Summary
- Automatically adds an empty `hooks` section to `config.json` when a project created before the hooks system is loaded
- Removes `skip_serializing_if = "Vec::is_empty"` from the `hooks` field so it's always serialized
- Adds normalization in `read_config` that detects a missing `hooks` key in the raw JSON and writes back the normalized config

## Details
When a project's `config.json` was created before the hooks system was introduced, it won't have a `hooks` section. This change ensures the daemon automatically adds an empty hooks section during config read when it detects one is missing, so all projects have the hooks configuration available without requiring a manual migration or edit.

The normalization only triggers a write-back when the `hooks` key is actually missing from the JSON - if it's already present (even as an empty array), the file is left untouched.

## Test plan
- [x] Unit test: config without hooks key gets normalized on read (hooks key added to file)
- [x] Unit test: config with hooks key already present is not rewritten
- [x] Unit test: hooks field is always present in serialized JSON even when empty
- [x] All 356 existing tests pass with no regressions
- [x] Clippy, rustfmt, and cspell checks pass

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)