### PR TITLE
fix: use proper shell escaping in terminal and editor commands (#146)

### DIFF
--- a/src/workspace/editor_config.rs
+++ b/src/workspace/editor_config.rs
@@ -180,7 +180,8 @@ pub fn open_editor_by_config(editor: &EditorConfig, workspace_path: &Path) -> bo
         return false;
     }
 
-    let command_str = editor.open_dir.replace("{dir}", &dir_str);
+    let escaped_dir = super::terminal::escape_path_for_shell(&dir_str);
+    let command_str = editor.open_dir.replace("{dir}", &escaped_dir);
 
     if editor.terminal_wrapper {
         // Run inside a platform terminal
@@ -203,7 +204,8 @@ pub async fn run_editor_setup(editor: &EditorConfig, workspace_path: &Path) {
 
     if let Some(ref setup_cmd) = editor.setup_workspace {
         let dir_str = workspace_path.to_string_lossy();
-        let cmd = setup_cmd.replace("{dir}", &dir_str);
+        let escaped_dir = super::terminal::escape_path_for_shell(&dir_str);
+        let cmd = setup_cmd.replace("{dir}", &escaped_dir);
 
         #[cfg(target_os = "windows")]
         let result = Command::new("cmd").arg("/C").arg(&cmd).output();


### PR DESCRIPTION
## Summary

- Add `escape_path_for_shell` helper using the existing `shell-escape` crate for consistent path escaping across all shell command construction
- Fix macOS AppleScript terminal: replace incomplete manual escaping with proper shell-escape + AppleScript string escaping
- Fix Linux xterm fallback and Windows cmd.exe fallback: use escaped paths instead of raw single/double-quote wrapping
- Fix editor_config: escape workspace paths in `open_dir` and `setup_workspace` template substitutions before passing to `sh -c` / `cmd /C`

Closes #146

## Test plan

- [x] All existing tests pass (358 unit + 118 integration)
- [x] New tests for `escape_path_for_shell` cover spaces, `$`, single quotes, backticks
- [x] Clippy pedantic passes with no new warnings
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)