### PR TITLE
feat: return errors in response body instead of gRPC status codes (#129)

### DIFF
--- a/proto/centy/v1/centy.proto
+++ b/proto/centy/v1/centy.proto
@@ -357,6 +357,9 @@ message ReconciliationPlan {
 
   // Whether user decisions are needed
   bool needs_decisions = 6;
+
+  bool success = 7;
+  string error = 8;
 }
 
 message ExecuteReconciliationRequest {
@@ -418,6 +421,8 @@ message GetNextIssueNumberRequest {
 
 message GetNextIssueNumberResponse {
   string issue_number = 1;
+  bool success = 2;
+  string error = 3;
 }
 
 // Issue represents a full issue with all its data
@@ -488,6 +493,8 @@ message GetIssuesByUuidResponse {
   repeated IssueWithProject issues = 1;
   int32 total_count = 2;
   repeated string errors = 3;     // Non-fatal errors (e.g., projects that couldn't be accessed)
+  bool success = 4;
+  string error = 5;
 }
 
 message ListIssuesRequest {
@@ -503,6 +510,8 @@ message ListIssuesRequest {
 message ListIssuesResponse {
   repeated Issue issues = 1;
   int32 total_count = 2;
+  bool success = 3;
+  string error = 4;
 }
 
 // Advanced search request
@@ -792,6 +801,8 @@ message GetDocsBySlugResponse {
   repeated DocWithProject docs = 1;
   int32 total_count = 2;
   repeated string errors = 3;         // Non-fatal errors (e.g., projects that couldn't be accessed)
+  bool success = 4;
+  string error = 5;
 }
 
 message ListDocsRequest {
@@ -802,6 +813,8 @@ message ListDocsRequest {
 message ListDocsResponse {
   repeated Doc docs = 1;
   int32 total_count = 2;
+  bool success = 3;
+  string error = 4;
 }
 
 // Doc represents a documentation file
@@ -946,6 +959,8 @@ message ListAssetsRequest {
 message ListAssetsResponse {
   repeated Asset assets = 1;
   int32 total_count = 2;
+  bool success = 3;
+  string error = 4;
 }
 
 message GetAssetRequest {
@@ -1013,6 +1028,8 @@ message ListProjectsRequest {
 message ListProjectsResponse {
   repeated ProjectInfo projects = 1;
   int32 total_count = 2;
+  bool success = 3;
+  string error = 4;
 }
 
 message RegisterProjectRequest {
@@ -1042,6 +1059,8 @@ message GetProjectInfoRequest {
 message GetProjectInfoResponse {
   bool found = 1;
   ProjectInfo project = 2;
+  bool success = 3;
+  string error = 4;
 }
 
 message SetProjectFavoriteRequest {
@@ -1137,6 +1156,8 @@ message ListOrganizationsRequest {}
 message ListOrganizationsResponse {
   repeated Organization organizations = 1;
   int32 total_count = 2;
+  bool success = 3;
+  string error = 4;
 }
 
 message GetOrganizationRequest {
@@ -1146,6 +1167,8 @@ message GetOrganizationRequest {
 message GetOrganizationResponse {
   bool found = 1;
   Organization organization = 2;
+  bool success = 3;
+  string error = 4;
 }
 
 message UpdateOrganizationRequest {
@@ -1246,6 +1269,8 @@ message GetNextPrNumberRequest {
 
 message GetNextPrNumberResponse {
   uint32 next_number = 1;
+  bool success = 2;
+  string error = 3;
 }
 
 // PullRequest represents a full PR with all its data
@@ -1314,6 +1339,8 @@ message GetPrsByUuidResponse {
   repeated PrWithProject prs = 1;
   int32 total_count = 2;
   repeated string errors = 3;         // Non-fatal errors (e.g., projects that couldn't be accessed)
+  bool success = 4;
+  string error = 5;
 }
 
 message ListPrsRequest {
@@ -1330,6 +1357,8 @@ message ListPrsRequest {
 message ListPrsResponse {
   repeated PullRequest prs = 1;
   int32 total_count = 2;
+  bool success = 3;
+  string error = 4;
 }
 
 message UpdatePrRequest {
@@ -1546,6 +1575,8 @@ message ListTempWorkspacesResponse {
   repeated TempWorkspace workspaces = 1;
   uint32 total_count = 2;
   uint32 expired_count = 3;             // Number of expired workspaces (not included unless include_expired)
+  bool success = 4;
+  string error = 5;
 }
 
 message CloseTempWorkspaceRequest {
@@ -1631,6 +1662,8 @@ message ListLinksRequest {
 message ListLinksResponse {
   repeated Link links = 1;
   int32 total_count = 2;
+  bool success = 3;
+  string error = 4;
 }
 
 // Get all available link types (builtin + custom)
@@ -1699,6 +1732,8 @@ message ListUsersRequest {
 message ListUsersResponse {
   repeated User users = 1;
   int32 total_count = 2;
+  bool success = 3;
+  string error = 4;
 }
 
 message UpdateUserRequest {

--- a/src/server/handlers/asset_read.rs
+++ b/src/server/handlers/asset_read.rs
@@ -20,9 +20,16 @@ pub async fn list_assets(req: ListAssetsRequest) -> Result<Response<ListAssetsRe
             Ok(Response::new(ListAssetsResponse {
                 assets: assets.iter().map(asset_info_to_proto).collect(),
                 total_count,
+                success: true,
+                error: String::new(),
             }))
         }
-        Err(e) => Err(Status::internal(e.to_string())),
+        Err(e) => Ok(Response::new(ListAssetsResponse {
+            success: false,
+            error: e.to_string(),
+            assets: vec![],
+            total_count: 0,
+        })),
     }
 }
 
@@ -71,8 +78,15 @@ pub async fn list_shared_assets(
             Ok(Response::new(ListAssetsResponse {
                 assets: assets.iter().map(asset_info_to_proto).collect(),
                 total_count,
+                success: true,
+                error: String::new(),
             }))
         }
-        Err(e) => Err(Status::internal(e.to_string())),
+        Err(e) => Ok(Response::new(ListAssetsResponse {
+            success: false,
+            error: e.to_string(),
+            assets: vec![],
+            total_count: 0,
+        })),
     }
 }

--- a/src/server/handlers/doc_read.rs
+++ b/src/server/handlers/doc_read.rs
@@ -34,7 +34,15 @@ pub async fn get_docs_by_slug_handler(
     // Get all initialized projects from registry
     let projects = match list_projects(ListProjectsOptions::default()).await {
         Ok(p) => p,
-        Err(e) => return Err(Status::internal(format!("Failed to list projects: {e}"))),
+        Err(e) => {
+            return Ok(Response::new(GetDocsBySlugResponse {
+                success: false,
+                error: format!("Failed to list projects: {e}"),
+                docs: vec![],
+                total_count: 0,
+                errors: vec![],
+            }))
+        }
     };
 
     match get_docs_by_slug(&req.slug, &projects).await {
@@ -56,9 +64,17 @@ pub async fn get_docs_by_slug_handler(
                 docs: docs_with_projects,
                 total_count,
                 errors: result.errors,
+                success: true,
+                error: String::new(),
             }))
         }
-        Err(e) => Err(Status::invalid_argument(e.to_string())),
+        Err(e) => Ok(Response::new(GetDocsBySlugResponse {
+            success: false,
+            error: e.to_string(),
+            docs: vec![],
+            total_count: 0,
+            errors: vec![],
+        })),
     }
 }
 
@@ -72,8 +88,15 @@ pub async fn list_docs_handler(req: ListDocsRequest) -> Result<Response<ListDocs
             Ok(Response::new(ListDocsResponse {
                 docs: docs.into_iter().map(|d| doc_to_proto(&d)).collect(),
                 total_count,
+                success: true,
+                error: String::new(),
             }))
         }
-        Err(e) => Err(Status::internal(e.to_string())),
+        Err(e) => Ok(Response::new(ListDocsResponse {
+            success: false,
+            error: e.to_string(),
+            docs: vec![],
+            total_count: 0,
+        })),
     }
 }

--- a/src/server/handlers/issue_by_uuid.rs
+++ b/src/server/handlers/issue_by_uuid.rs
@@ -12,7 +12,15 @@ pub async fn get_issues_by_uuid(
     // Get all initialized projects from registry
     let projects = match list_projects(ListProjectsOptions::default()).await {
         Ok(p) => p,
-        Err(e) => return Err(Status::internal(format!("Failed to list projects: {e}"))),
+        Err(e) => {
+            return Ok(Response::new(GetIssuesByUuidResponse {
+                success: false,
+                error: format!("Failed to list projects: {e}"),
+                issues: vec![],
+                total_count: 0,
+                errors: vec![],
+            }))
+        }
     };
 
     match crate::item::entities::issue::get_issues_by_uuid(&req.uuid, &projects).await {
@@ -39,8 +47,16 @@ pub async fn get_issues_by_uuid(
                 issues: issues_with_projects,
                 total_count,
                 errors: result.errors,
+                success: true,
+                error: String::new(),
             }))
         }
-        Err(e) => Err(Status::invalid_argument(e.to_string())),
+        Err(e) => Ok(Response::new(GetIssuesByUuidResponse {
+            success: false,
+            error: e.to_string(),
+            issues: vec![],
+            total_count: 0,
+            errors: vec![],
+        })),
     }
 }

--- a/src/server/handlers/issue_list.rs
+++ b/src/server/handlers/issue_list.rs
@@ -45,8 +45,15 @@ pub async fn list_issues(req: ListIssuesRequest) -> Result<Response<ListIssuesRe
                     .map(|i| issue_to_proto(&i, priority_levels))
                     .collect(),
                 total_count,
+                success: true,
+                error: String::new(),
             }))
         }
-        Err(e) => Err(Status::internal(e.to_string())),
+        Err(e) => Ok(Response::new(ListIssuesResponse {
+            success: false,
+            error: e.to_string(),
+            issues: vec![],
+            total_count: 0,
+        })),
     }
 }

--- a/src/server/handlers/issue_read.rs
+++ b/src/server/handlers/issue_read.rs
@@ -71,7 +71,15 @@ pub async fn get_next_issue_number(
 
     #[allow(deprecated)]
     match crate::item::entities::issue::create::get_next_issue_number(&issues_path).await {
-        Ok(issue_number) => Ok(Response::new(GetNextIssueNumberResponse { issue_number })),
-        Err(e) => Err(Status::internal(e.to_string())),
+        Ok(issue_number) => Ok(Response::new(GetNextIssueNumberResponse {
+            issue_number,
+            success: true,
+            error: String::new(),
+        })),
+        Err(e) => Ok(Response::new(GetNextIssueNumberResponse {
+            success: false,
+            error: e.to_string(),
+            issue_number: String::new(),
+        })),
     }
 }

--- a/src/server/handlers/link_read.rs
+++ b/src/server/handlers/link_read.rs
@@ -24,8 +24,15 @@ pub async fn list_links(req: ListLinksRequest) -> Result<Response<ListLinksRespo
                 .map(internal_link_to_proto)
                 .collect(),
             total_count: links_file.links.len() as i32,
+            success: true,
+            error: String::new(),
         })),
-        Err(e) => Err(Status::internal(e.to_string())),
+        Err(e) => Ok(Response::new(ListLinksResponse {
+            success: false,
+            error: e.to_string(),
+            links: vec![],
+            total_count: 0,
+        })),
     }
 }
 

--- a/src/server/handlers/organization.rs
+++ b/src/server/handlers/organization.rs
@@ -42,9 +42,16 @@ pub async fn list_organizations(
             Ok(Response::new(ListOrganizationsResponse {
                 organizations: orgs.into_iter().map(|o| org_info_to_proto(&o)).collect(),
                 total_count,
+                success: true,
+                error: String::new(),
             }))
         }
-        Err(e) => Err(Status::internal(e.to_string())),
+        Err(e) => Ok(Response::new(ListOrganizationsResponse {
+            success: false,
+            error: e.to_string(),
+            organizations: vec![],
+            total_count: 0,
+        })),
     }
 }
 
@@ -55,11 +62,20 @@ pub async fn get_organization(
         Ok(Some(org)) => Ok(Response::new(GetOrganizationResponse {
             found: true,
             organization: Some(org_info_to_proto(&org)),
+            success: true,
+            error: String::new(),
         })),
         Ok(None) => Ok(Response::new(GetOrganizationResponse {
             found: false,
             organization: None,
+            success: true,
+            error: String::new(),
         })),
-        Err(e) => Err(Status::internal(e.to_string())),
+        Err(e) => Ok(Response::new(GetOrganizationResponse {
+            success: false,
+            error: e.to_string(),
+            found: false,
+            organization: None,
+        })),
     }
 }

--- a/src/server/handlers/pr_by_uuid.rs
+++ b/src/server/handlers/pr_by_uuid.rs
@@ -13,7 +13,15 @@ pub async fn get_prs_by_uuid(
     // Get all initialized projects from registry
     let projects = match list_projects(ListProjectsOptions::default()).await {
         Ok(p) => p,
-        Err(e) => return Err(Status::internal(format!("Failed to list projects: {e}"))),
+        Err(e) => {
+            return Ok(Response::new(GetPrsByUuidResponse {
+                success: false,
+                error: format!("Failed to list projects: {e}"),
+                prs: vec![],
+                total_count: 0,
+                errors: vec![],
+            }))
+        }
     };
 
     match crate::item::entities::pr::get_prs_by_uuid(&req.uuid, &projects).await {
@@ -40,8 +48,16 @@ pub async fn get_prs_by_uuid(
                 prs: prs_with_projects,
                 total_count,
                 errors: result.errors,
+                success: true,
+                error: String::new(),
             }))
         }
-        Err(e) => Err(Status::invalid_argument(e.to_string())),
+        Err(e) => Ok(Response::new(GetPrsByUuidResponse {
+            success: false,
+            error: e.to_string(),
+            prs: vec![],
+            total_count: 0,
+            errors: vec![],
+        })),
     }
 }

--- a/src/server/handlers/pr_list.rs
+++ b/src/server/handlers/pr_list.rs
@@ -54,8 +54,15 @@ pub async fn list_prs(req: ListPrsRequest) -> Result<Response<ListPrsResponse>, 
                     .map(|p| pr_to_proto(&p, priority_levels))
                     .collect(),
                 total_count,
+                success: true,
+                error: String::new(),
             }))
         }
-        Err(e) => Err(Status::internal(e.to_string())),
+        Err(e) => Ok(Response::new(ListPrsResponse {
+            success: false,
+            error: e.to_string(),
+            prs: vec![],
+            total_count: 0,
+        })),
     }
 }

--- a/src/server/handlers/pr_read.rs
+++ b/src/server/handlers/pr_read.rs
@@ -69,7 +69,15 @@ pub async fn get_next_pr_number(
     let prs_path = get_centy_path(project_path).join("prs");
 
     match get_next_pr_display_number(&prs_path).await {
-        Ok(next_number) => Ok(Response::new(GetNextPrNumberResponse { next_number })),
-        Err(e) => Err(Status::internal(e.to_string())),
+        Ok(next_number) => Ok(Response::new(GetNextPrNumberResponse {
+            next_number,
+            success: true,
+            error: String::new(),
+        })),
+        Err(e) => Ok(Response::new(GetNextPrNumberResponse {
+            success: false,
+            error: e.to_string(),
+            next_number: 0,
+        })),
     }
 }

--- a/src/server/handlers/project.rs
+++ b/src/server/handlers/project.rs
@@ -31,9 +31,16 @@ pub async fn list_projects(
                     .map(|p| project_info_to_proto(&p))
                     .collect(),
                 total_count,
+                success: true,
+                error: String::new(),
             }))
         }
-        Err(e) => Err(Status::internal(e.to_string())),
+        Err(e) => Ok(Response::new(ListProjectsResponse {
+            success: false,
+            error: e.to_string(),
+            projects: vec![],
+            total_count: 0,
+        })),
     }
 }
 
@@ -59,11 +66,20 @@ pub async fn get_project_info(
         Ok(Some(info)) => Ok(Response::new(GetProjectInfoResponse {
             found: true,
             project: Some(project_info_to_proto(&info)),
+            success: true,
+            error: String::new(),
         })),
         Ok(None) => Ok(Response::new(GetProjectInfoResponse {
             found: false,
             project: None,
+            success: true,
+            error: String::new(),
         })),
-        Err(e) => Err(Status::internal(e.to_string())),
+        Err(e) => Ok(Response::new(GetProjectInfoResponse {
+            success: false,
+            error: e.to_string(),
+            found: false,
+            project: None,
+        })),
     }
 }

--- a/src/server/handlers/reconciliation.rs
+++ b/src/server/handlers/reconciliation.rs
@@ -40,9 +40,15 @@ pub async fn get_reconciliation_plan(
                     .map(file_info_to_proto)
                     .collect(),
                 needs_decisions,
+                success: true,
+                error: String::new(),
             }))
         }
-        Err(e) => Err(Status::internal(e.to_string())),
+        Err(e) => Ok(Response::new(ReconciliationPlan {
+            success: false,
+            error: e.to_string(),
+            ..Default::default()
+        })),
     }
 }
 pub async fn execute_reconciliation_handler(

--- a/src/server/handlers/user_read.rs
+++ b/src/server/handlers/user_read.rs
@@ -40,8 +40,15 @@ pub async fn list_users(req: ListUsersRequest) -> Result<Response<ListUsersRespo
             Ok(Response::new(ListUsersResponse {
                 users: users.iter().map(user_to_proto).collect(),
                 total_count,
+                success: true,
+                error: String::new(),
             }))
         }
-        Err(e) => Err(Status::internal(e.to_string())),
+        Err(e) => Ok(Response::new(ListUsersResponse {
+            success: false,
+            error: e.to_string(),
+            users: vec![],
+            total_count: 0,
+        })),
     }
 }

--- a/src/server/handlers/workspace_manage.rs
+++ b/src/server/handlers/workspace_manage.rs
@@ -74,9 +74,17 @@ pub async fn list_temp_workspaces(
                 total_count: proto_workspaces.len() as u32,
                 workspaces: proto_workspaces,
                 expired_count,
+                success: true,
+                error: String::new(),
             }))
         }
-        Err(e) => Err(Status::internal(e.to_string())),
+        Err(e) => Ok(Response::new(ListTempWorkspacesResponse {
+            success: false,
+            error: e.to_string(),
+            workspaces: vec![],
+            total_count: 0,
+            expired_count: 0,
+        })),
     }
 }
 


### PR DESCRIPTION
## Summary
- Added `success` and `error` fields to 17 v1 proto response messages that were missing them
- Converted all 21 `Err(Status::...)` handlers in the gRPC server to return `Ok(Response::new(...))` with `success: false` and error text in the response body
- This standardizes error handling so clients can always read errors from the response body's `success`/`error` fields, instead of having to handle gRPC transport-level status codes separately

## Test plan
- [x] `cargo check --all-targets` passes
- [x] `cargo test --all-targets` passes (827+ tests, 0 failures)
- [x] `cargo clippy` clean (only pre-existing `too_many_lines` warnings)
- [x] Pre-commit hooks pass (cspell, clippy, formatting)
- [x] Pre-push hooks pass (full test suite)
- [x] v2 proto has no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)