### PR TITLE
feat: extract ConfigService from CentyDaemon (#158)

### DIFF
--- a/e2e/fixtures/cli-wrapper.ts
+++ b/e2e/fixtures/cli-wrapper.ts
@@ -41,8 +41,8 @@ export class CLIWrapper {
   constructor(options: CLIWrapperOptions) {
     this.cwd = options.cwd;
     this.verbose = options.verbose ?? false;
-    const rawClient = createGrpcClient(options.daemonAddress ?? '127.0.0.1:50051');
-    this.client = promisifyClient(rawClient);
+    const { centyClient, configClient } = createGrpcClient(options.daemonAddress ?? '127.0.0.1:50051');
+    this.client = promisifyClient(centyClient, configClient);
   }
 
   /**

--- a/e2e/fixtures/temp-project.ts
+++ b/e2e/fixtures/temp-project.ts
@@ -46,8 +46,8 @@ export async function createTempProject(
   await mkdir(projectPath, { recursive: true });
 
   const centyPath = join(projectPath, '.centy');
-  const rawClient = createGrpcClient(opts.daemonAddress);
-  const client = promisifyClient(rawClient);
+  const { centyClient, configClient } = createGrpcClient(opts.daemonAddress);
+  const client = promisifyClient(centyClient, configClient);
 
   // Initialize if requested
   if (opts.initialize) {
@@ -264,8 +264,8 @@ export async function createTempGitProject(
   }
 
   const centyPath = join(projectPath, '.centy');
-  const rawClient = createGrpcClient(opts.daemonAddress);
-  const client = promisifyClient(rawClient);
+  const { centyClient, configClient } = createGrpcClient(opts.daemonAddress);
+  const client = promisifyClient(centyClient, configClient);
 
   // Initialize centy if requested
   if (opts.initialize) {

--- a/proto/centy/v1/centy.proto
+++ b/proto/centy/v1/centy.proto
@@ -52,15 +52,6 @@ service CentyDaemon {
   // Get the next issue number
   rpc GetNextIssueNumber(GetNextIssueNumberRequest) returns (GetNextIssueNumberResponse);
 
-  // Read the manifest
-  rpc GetManifest(GetManifestRequest) returns (GetManifestResponse);
-
-  // Read configuration
-  rpc GetConfig(GetConfigRequest) returns (GetConfigResponse);
-
-  // Update configuration
-  rpc UpdateConfig(UpdateConfigRequest) returns (UpdateConfigResponse);
-
   // Check if centy is initialized in a directory
   rpc IsInitialized(IsInitializedRequest) returns (IsInitializedResponse);
 
@@ -303,6 +294,18 @@ service CentyDaemon {
 
   // Manually trigger a sync push
   rpc SyncPush(SyncPushRequest) returns (SyncPushResponse);
+}
+
+// ConfigService - manages project configuration and manifest
+service ConfigService {
+  // Read the manifest
+  rpc GetManifest(GetManifestRequest) returns (GetManifestResponse);
+
+  // Read configuration
+  rpc GetConfig(GetConfigRequest) returns (GetConfigResponse);
+
+  // Update configuration
+  rpc UpdateConfig(UpdateConfigRequest) returns (UpdateConfigResponse);
 }
 
 // ============ Init Messages ============

--- a/src/server/config_trait_impl.rs
+++ b/src/server/config_trait_impl.rs
@@ -1,0 +1,30 @@
+use tonic::{Request, Response, Status};
+
+use super::handlers;
+use super::proto::config_service_server::ConfigService;
+use super::proto::*;
+use super::ConfigServiceImpl;
+
+#[tonic::async_trait]
+impl ConfigService for ConfigServiceImpl {
+    async fn get_manifest(
+        &self,
+        request: Request<GetManifestRequest>,
+    ) -> Result<Response<GetManifestResponse>, Status> {
+        handlers::manifest::get_manifest(request.into_inner()).await
+    }
+
+    async fn get_config(
+        &self,
+        request: Request<GetConfigRequest>,
+    ) -> Result<Response<GetConfigResponse>, Status> {
+        handlers::config::get_config(request.into_inner()).await
+    }
+
+    async fn update_config(
+        &self,
+        request: Request<UpdateConfigRequest>,
+    ) -> Result<Response<UpdateConfigResponse>, Status> {
+        handlers::config_update::update_config(request.into_inner()).await
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2,6 +2,7 @@ mod action_builders;
 mod action_builders_extra;
 mod actions;
 mod config_to_proto;
+mod config_trait_impl;
 mod convert_entity;
 mod convert_infra;
 mod convert_link;
@@ -50,5 +51,20 @@ impl CentyDaemonService {
             shutdown_tx,
             exe_path,
         }
+    }
+}
+
+pub struct ConfigServiceImpl;
+
+impl Default for ConfigServiceImpl {
+    fn default() -> Self {
+        Self
+    }
+}
+
+impl ConfigServiceImpl {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
     }
 }

--- a/src/server/trait_impl.rs
+++ b/src/server/trait_impl.rs
@@ -135,27 +135,6 @@ impl CentyDaemon for CentyDaemonService {
         handlers::issue_read::get_next_issue_number(request.into_inner()).await
     }
 
-    async fn get_manifest(
-        &self,
-        request: Request<GetManifestRequest>,
-    ) -> Result<Response<GetManifestResponse>, Status> {
-        handlers::manifest::get_manifest(request.into_inner()).await
-    }
-
-    async fn get_config(
-        &self,
-        request: Request<GetConfigRequest>,
-    ) -> Result<Response<GetConfigResponse>, Status> {
-        handlers::config::get_config(request.into_inner()).await
-    }
-
-    async fn update_config(
-        &self,
-        request: Request<UpdateConfigRequest>,
-    ) -> Result<Response<UpdateConfigResponse>, Status> {
-        handlers::config_update::update_config(request.into_inner()).await
-    }
-
     async fn is_initialized(
         &self,
         request: Request<IsInitializedRequest>,


### PR DESCRIPTION
## Summary
- Extract `GetManifest`, `GetConfig`, and `UpdateConfig` RPCs from the monolithic `CentyDaemon` service into a new `ConfigService` in the same proto file and package
- Add `ConfigServiceImpl` in Rust with a new `config_trait_impl.rs` that delegates to existing handler functions
- Register the new `ConfigServiceServer` on the same tonic server/port alongside `CentyDaemonServer`
- Update E2E gRPC client fixtures to create a separate `ConfigClient` for the new service while keeping the promisified API surface unchanged

## Test plan
- [x] `cargo build` compiles successfully with both service modules
- [x] `cargo test` — all 594+ unit/integration tests pass
- [x] Pre-push hooks pass (clippy, formatting, type checking, full test suite)
- [ ] `cd e2e && pnpm test -- config` — e2e config tests pass against the new service
- [ ] gRPC reflection shows both `CentyDaemon` and `ConfigService`

🤖 Generated with [Claude Code](https://claude.com/claude-code)