### PR TITLE
feat: add projects field to item metadata and wire through proto

### DIFF
--- a/src/server/convert_entity.rs
+++ b/src/server/convert_entity.rs
@@ -21,10 +21,21 @@ pub fn generic_item_to_proto(item: &mdstore::Item, item_type: &str) -> ProtoGene
                 .frontmatter
                 .custom_fields
                 .iter()
+                .filter(|(k, _)| k.as_str() != "projects")
                 .map(|(k, v)| (k.clone(), v.to_string()))
                 .collect(),
             tags: item.frontmatter.tags.clone().unwrap_or_default(),
-            projects: vec![],
+            projects: item
+                .frontmatter
+                .custom_fields
+                .get("projects")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(str::to_string))
+                        .collect()
+                })
+                .unwrap_or_default(),
         }),
     }
 }

--- a/src/server/convert_entity_tests.rs
+++ b/src/server/convert_entity_tests.rs
@@ -99,6 +99,28 @@ fn test_generic_item_to_proto_with_custom_fields() {
 }
 
 #[test]
+fn test_generic_item_to_proto_with_projects() {
+    let custom_fields = HashMap::from([(
+        "projects".to_string(),
+        serde_json::json!(["frontend", "backend"]),
+    )]);
+    let item = make_item(None, None, None, None, None, custom_fields);
+    let proto = generic_item_to_proto(&item, "issue");
+    let meta = proto.metadata.unwrap();
+    assert_eq!(meta.projects, vec!["frontend", "backend"]);
+    // projects must not leak into the custom_fields map
+    assert!(!meta.custom_fields.contains_key("projects"));
+}
+
+#[test]
+fn test_generic_item_to_proto_projects_default_empty() {
+    let item = make_item(None, None, None, None, None, HashMap::new());
+    let proto = generic_item_to_proto(&item, "issue");
+    let meta = proto.metadata.unwrap();
+    assert!(meta.projects.is_empty());
+}
+
+#[test]
 fn test_user_to_proto_with_email() {
     let user = crate::user::User {
         id: "alice".to_string(),

--- a/src/server/handlers/item_create/handler.rs
+++ b/src/server/handlers/item_create/handler.rs
@@ -53,6 +53,7 @@ pub async fn create_item(req: CreateItemRequest) -> Result<Response<CreateItemRe
         nonempty(req.status),
         nonzero_u32(req.priority),
         req.tags,
+        &req.projects,
         req.custom_fields,
     );
     Ok(Response::new(

--- a/src/server/handlers/item_create/operation.rs
+++ b/src/server/handlers/item_create/operation.rs
@@ -61,15 +61,19 @@ pub(super) fn build_options(
     status: Option<String>,
     priority: Option<u32>,
     tags: Vec<String>,
+    projects: &[String],
     custom_fields_raw: HashMap<String, String>,
 ) -> CreateOptions {
-    let custom_fields = custom_fields_raw
+    let mut custom_fields: HashMap<String, serde_json::Value> = custom_fields_raw
         .into_iter()
         .map(|(k, v)| {
             let val = serde_json::from_str(&v).unwrap_or(serde_json::Value::String(v));
             (k, val)
         })
         .collect();
+    if !projects.is_empty() {
+        custom_fields.insert("projects".to_string(), serde_json::json!(projects));
+    }
     CreateOptions {
         title,
         body,

--- a/tests/generic_rpc_test.rs
+++ b/tests/generic_rpc_test.rs
@@ -190,7 +190,6 @@ async fn test_list_with_filters() {
         filter: String::new(),
         limit: 0,
         offset: 0,
-        include_organization_items: None,
     })
     .await
     .unwrap()
@@ -205,7 +204,6 @@ async fn test_list_with_filters() {
         filter: r#"{"status":"open"}"#.to_string(),
         limit: 0,
         offset: 0,
-        include_organization_items: None,
     })
     .await
     .unwrap()
@@ -219,7 +217,6 @@ async fn test_list_with_filters() {
         filter: r#"{"priority":1}"#.to_string(),
         limit: 0,
         offset: 0,
-        include_organization_items: None,
     })
     .await
     .unwrap()
@@ -233,7 +230,6 @@ async fn test_list_with_filters() {
         filter: String::new(),
         limit: 1,
         offset: 1,
-        include_organization_items: None,
     })
     .await
     .unwrap()
@@ -383,7 +379,6 @@ async fn test_soft_delete_and_restore() {
         filter: String::new(),
         limit: 0,
         offset: 0,
-        include_organization_items: None,
     })
     .await
     .unwrap()
@@ -397,7 +392,6 @@ async fn test_soft_delete_and_restore() {
         filter: r#"{"deletedAt":{"$exists":true}}"#.to_string(),
         limit: 0,
         offset: 0,
-        include_organization_items: None,
     })
     .await
     .unwrap()
@@ -424,7 +418,6 @@ async fn test_soft_delete_and_restore() {
         filter: String::new(),
         limit: 0,
         offset: 0,
-        include_organization_items: None,
     })
     .await
     .unwrap()


### PR DESCRIPTION
## Summary

- Wire `projects: Vec<String>` through the item metadata lifecycle: stored via `mdstore` custom_fields (flattened YAML), extracted in `convert_entity.rs` for the proto response, and threaded from `CreateItemRequest.projects` through `build_options` into the stored frontmatter
- Exclude `projects` from the proto `custom_fields` map so it only appears in the dedicated `projects` field
- Add 2 new unit tests: `test_generic_item_to_proto_with_projects` and `test_generic_item_to_proto_projects_default_empty`
- Fix pre-existing test compilation error: remove non-existent `include_organization_items` field from `ListItemsRequest` in `generic_rpc_test.rs`
- Update proto submodule to latest main (`30743f9`) which includes the already-merged projects field and UpdateLink changes

Closes #385

## Test plan

- [x] `cargo test --lib` — 775 tests pass (including 2 new convert_entity tests)
- [x] e2e tests pass (112 passed, 25 skipped)
- [x] Backwards-compatible: existing items without `projects` in frontmatter deserialize as empty list

🤖 Generated with [Claude Code](https://claude.com/claude-code)