### PR TITLE
refactor: split workspace_temp handler into focused modules

### DIFF
--- a/.centy/issues/d2d796fb-ad17-4e43-8a15-3035e3f8c2f7.md
+++ b/.centy/issues/d2d796fb-ad17-4e43-8a15-3035e3f8c2f7.md
@@ -1,10 +1,10 @@
 ---
 # This file is managed by Centy. Use the Centy CLI to modify it.
 displayNumber: 398
-status: in-progress
+status: closed
 priority: 2
 createdAt: 2026-04-04T11:55:40.212144+00:00
-updatedAt: 2026-04-04T12:04:27.824541+00:00
+updatedAt: 2026-04-04T12:14:30.026246+00:00
 ---
 
 # Split workspace_temp handler — separate creation, editor, and hooks phases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Split `init/mcp_json.rs`: pure JSON logic stays in `mcp_json.rs`; async file I/O extracted into new `mcp_io.rs`
+- Refactored `workspace_temp` handler into focused modules: `hooks.rs` (status update), `operations/create.rs` (workspace creation), `operations/editor.rs` (editor invocation), with `handler.rs` as thin orchestration
 
 ### Added
 - `UpdateLink` gRPC endpoint for changing the link type of an existing link

--- a/src/server/handlers/workspace_temp/handler.rs
+++ b/src/server/handlers/workspace_temp/handler.rs
@@ -1,57 +1,15 @@
-use super::editor::{open_editor_with_hooks, try_update_status_on_open};
+use super::hooks::try_update_status_on_open;
+use super::operations::run_create_workspace;
 use super::response::err_response;
 use crate::config::read_config;
-use crate::item::entities::issue::Issue;
 use crate::registry::track_project_async;
 use crate::server::assert_service::assert_initialized;
 use crate::server::proto::{OpenInTempWorkspaceResponse, OpenInTempWorkspaceWithEditorRequest};
 use crate::server::resolve::resolve_issue;
 use crate::server::structured_error::{to_error_json, StructuredError};
-use crate::workspace::{create_temp_workspace, CreateWorkspaceOptions};
 use std::path::Path;
 use tonic::{Response, Status};
 
-async fn run_create_workspace(
-    project_path: &Path,
-    req_project_path: &str,
-    req_editor_id: &str,
-    issue: Issue,
-) -> Result<Response<OpenInTempWorkspaceResponse>, Status> {
-    match create_temp_workspace(CreateWorkspaceOptions {
-        source_project_path: project_path.to_path_buf(),
-        issue: issue.clone(),
-    })
-    .await
-    {
-        Ok(result) => {
-            let workspace_path = result.workspace_path.to_string_lossy().to_string();
-            let editor_opened = open_editor_with_hooks(
-                req_editor_id,
-                &workspace_path,
-                issue.metadata.display_number,
-                project_path,
-            );
-            Ok(Response::new(OpenInTempWorkspaceResponse {
-                success: true,
-                error: String::new(),
-                workspace_path,
-                issue_id: issue.id.clone(),
-                display_number: issue.metadata.display_number,
-                expires_at: String::new(),
-                editor_opened,
-                requires_status_config: false,
-                workspace_reused: result.workspace_reused,
-                original_created_at: String::new(),
-            }))
-        }
-        Err(e) => Ok(err_response(
-            to_error_json(req_project_path, &e),
-            String::new(),
-            0,
-            false,
-        )),
-    }
-}
 pub async fn open_in_temp_workspace(
     req: OpenInTempWorkspaceWithEditorRequest,
 ) -> Result<Response<OpenInTempWorkspaceResponse>, Status> {
@@ -83,10 +41,14 @@ pub async fn open_in_temp_workspace(
     if requires_status_config {
         return Ok(err_response(
             StructuredError::new(
-                &req.project_path, "STATUS_CONFIG_REQUIRED",
+                &req.project_path,
+                "STATUS_CONFIG_REQUIRED",
                 "Status update preference not configured. Set workspace.updateStatusOnOpen in your project config.".to_string(),
-            ).to_json(),
-            issue.id.clone(), issue.metadata.display_number, true,
+            )
+            .to_json(),
+            issue.id.clone(),
+            issue.metadata.display_number,
+            true,
         ));
     }
     try_update_status_on_open(

--- a/src/server/handlers/workspace_temp/hooks.rs
+++ b/src/server/handlers/workspace_temp/hooks.rs
@@ -1,0 +1,28 @@
+use crate::item::entities::issue::{update_issue, UpdateIssueOptions};
+use std::path::Path;
+
+pub(super) async fn try_update_status_on_open(
+    config: Option<&crate::config::CentyConfig>,
+    project_path: &Path,
+    issue_id: &str,
+    current_status: &str,
+) {
+    if let Some(cfg) = config {
+        if cfg.workspace.update_status_on_open == Some(true)
+            && current_status != "in-progress"
+            && current_status != "closed"
+        {
+            drop(
+                update_issue(
+                    project_path,
+                    issue_id,
+                    UpdateIssueOptions {
+                        status: Some("in-progress".to_string()),
+                        ..Default::default()
+                    },
+                )
+                .await,
+            );
+        }
+    }
+}

--- a/src/server/handlers/workspace_temp/mod.rs
+++ b/src/server/handlers/workspace_temp/mod.rs
@@ -1,4 +1,5 @@
-mod editor;
 mod handler;
+mod hooks;
+mod operations;
 mod response;
 pub use handler::open_in_temp_workspace;

--- a/src/server/handlers/workspace_temp/operations/create.rs
+++ b/src/server/handlers/workspace_temp/operations/create.rs
@@ -1,5 +1,5 @@
-use super::editor::open_editor_with_hooks;
 use super::super::response::err_response;
+use super::editor::open_editor_with_hooks;
 use crate::item::entities::issue::Issue;
 use crate::server::proto::OpenInTempWorkspaceResponse;
 use crate::server::structured_error::to_error_json;

--- a/src/server/handlers/workspace_temp/operations/create.rs
+++ b/src/server/handlers/workspace_temp/operations/create.rs
@@ -1,0 +1,50 @@
+use super::editor::open_editor_with_hooks;
+use super::super::response::err_response;
+use crate::item::entities::issue::Issue;
+use crate::server::proto::OpenInTempWorkspaceResponse;
+use crate::server::structured_error::to_error_json;
+use crate::workspace::{create_temp_workspace, CreateWorkspaceOptions};
+use std::path::Path;
+use tonic::{Response, Status};
+
+pub async fn run_create_workspace(
+    project_path: &Path,
+    req_project_path: &str,
+    req_editor_id: &str,
+    issue: Issue,
+) -> Result<Response<OpenInTempWorkspaceResponse>, Status> {
+    match create_temp_workspace(CreateWorkspaceOptions {
+        source_project_path: project_path.to_path_buf(),
+        issue: issue.clone(),
+    })
+    .await
+    {
+        Ok(result) => {
+            let workspace_path = result.workspace_path.to_string_lossy().to_string();
+            let editor_opened = open_editor_with_hooks(
+                req_editor_id,
+                &workspace_path,
+                issue.metadata.display_number,
+                project_path,
+            );
+            Ok(Response::new(OpenInTempWorkspaceResponse {
+                success: true,
+                error: String::new(),
+                workspace_path,
+                issue_id: issue.id.clone(),
+                display_number: issue.metadata.display_number,
+                expires_at: String::new(),
+                editor_opened,
+                requires_status_config: false,
+                workspace_reused: result.workspace_reused,
+                original_created_at: String::new(),
+            }))
+        }
+        Err(e) => Ok(err_response(
+            to_error_json(req_project_path, &e),
+            String::new(),
+            0,
+            false,
+        )),
+    }
+}

--- a/src/server/handlers/workspace_temp/operations/editor.rs
+++ b/src/server/handlers/workspace_temp/operations/editor.rs
@@ -1,31 +1,4 @@
-use crate::item::entities::issue::{update_issue, UpdateIssueOptions};
 use std::path::Path;
-
-pub(super) async fn try_update_status_on_open(
-    config: Option<&crate::config::CentyConfig>,
-    project_path: &Path,
-    issue_id: &str,
-    current_status: &str,
-) {
-    if let Some(cfg) = config {
-        if cfg.workspace.update_status_on_open == Some(true)
-            && current_status != "in-progress"
-            && current_status != "closed"
-        {
-            drop(
-                update_issue(
-                    project_path,
-                    issue_id,
-                    UpdateIssueOptions {
-                        status: Some("in-progress".to_string()),
-                        ..Default::default()
-                    },
-                )
-                .await,
-            );
-        }
-    }
-}
 
 pub(super) fn open_editor_with_hooks(
     editor_id: &str,

--- a/src/server/handlers/workspace_temp/operations/mod.rs
+++ b/src/server/handlers/workspace_temp/operations/mod.rs
@@ -1,0 +1,3 @@
+mod create;
+mod editor;
+pub use create::run_create_workspace;


### PR DESCRIPTION
## Summary
- Extract status-update hook logic into `hooks.rs`
- Move workspace creation logic into `operations/create.rs`
- Move editor invocation into `operations/editor.rs`
- Leave `handler.rs` as thin orchestration only

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)