### PR TITLE
refactor: split link_create handler into focused modules

### DIFF
--- a/.centy/issues/e568549b-1ce6-4c7d-8233-bde2c6701ff2.md
+++ b/.centy/issues/e568549b-1ce6-4c7d-8233-bde2c6701ff2.md
@@ -1,10 +1,10 @@
 ---
 # This file is managed by Centy. Use the Centy CLI to modify it.
 displayNumber: 395
-status: open
+status: closed
 priority: 2
 createdAt: 2026-04-04T11:55:29.814595+00:00
-updatedAt: 2026-04-04T11:55:29.814595+00:00
+updatedAt: 2026-04-04T13:21:00.764805+00:00
 ---
 
 # Thin out link_create handler — extract validation, resolution, and hooks

--- a/src/server/handlers/link_create/hooks.rs
+++ b/src/server/handlers/link_create/hooks.rs
@@ -1,0 +1,20 @@
+use crate::hooks::{HookError, HookOperation};
+use crate::server::hooks_helper::maybe_run_pre_hooks;
+use std::path::Path;
+
+pub(super) async fn run_pre_hooks(
+    project_path: &Path,
+    project_path_str: &str,
+    item_id: &str,
+    request_data: serde_json::Value,
+) -> Result<(), HookError> {
+    maybe_run_pre_hooks(
+        project_path,
+        "link",
+        HookOperation::Create,
+        project_path_str,
+        Some(item_id),
+        Some(request_data),
+    )
+    .await
+}

--- a/src/server/handlers/link_create/mod.rs
+++ b/src/server/handlers/link_create/mod.rs
@@ -1,17 +1,16 @@
 use crate::config::read_config;
-use crate::hooks::HookOperation;
 use crate::link::{CreateLinkOptions, TargetType};
 use crate::registry::track_project_async;
-use crate::server::assert_service::assert_initialized;
 use crate::server::error_mapping::ToStructuredError;
-use crate::server::handlers::item_type_resolve::{resolve_item_id, resolve_item_type_config};
-use crate::server::hooks_helper::maybe_run_pre_hooks;
 use crate::server::proto::{CreateLinkRequest, CreateLinkResponse};
 use crate::server::structured_error::to_error_json;
 use std::path::Path;
 use tonic::{Response, Status};
 
 mod core;
+mod hooks;
+mod resolution;
+mod validation;
 
 fn err_resp(
     cwd: &str,
@@ -27,7 +26,7 @@ fn err_resp(
 pub async fn create_link(req: CreateLinkRequest) -> Result<Response<CreateLinkResponse>, Status> {
     track_project_async(req.project_path.clone());
     let project_path = Path::new(&req.project_path);
-    if let Err(e) = assert_initialized(project_path) {
+    if let Err(e) = validation::check_initialized(project_path) {
         return Ok(err_resp(&req.project_path, &e));
     }
     let hook_project_path = req.project_path.clone();
@@ -35,13 +34,11 @@ pub async fn create_link(req: CreateLinkRequest) -> Result<Response<CreateLinkRe
     let hook_request_data = serde_json::json!({
         "source_id": &req.source_id, "target_id": &req.target_id, "link_type": &req.link_type,
     });
-    if let Err(e) = maybe_run_pre_hooks(
+    if let Err(e) = hooks::run_pre_hooks(
         project_path,
-        "link",
-        HookOperation::Create,
         &hook_project_path,
-        Some(&hook_item_id),
-        Some(hook_request_data.clone()),
+        &hook_item_id,
+        hook_request_data.clone(),
     )
     .await
     {
@@ -49,27 +46,18 @@ pub async fn create_link(req: CreateLinkRequest) -> Result<Response<CreateLinkRe
     }
     let source_type = TargetType::new(req.source_item_type.to_lowercase());
     let target_type = TargetType::new(req.target_item_type.to_lowercase());
-
-    // Resolve display numbers to UUIDs, scoped to each item's type.
-    let source_id = match resolve_item_type_config(project_path, source_type.as_str()).await {
-        Ok((folder, config)) => {
-            match resolve_item_id(project_path, &folder, &config, &req.source_id).await {
-                Ok(id) => id,
-                Err(e) => return Ok(err_resp(&req.project_path, &e)),
-            }
-        }
-        Err(_) => req.source_id.clone(),
+    let (source_id, target_id) = match resolution::resolve_link_ids(
+        project_path,
+        &source_type,
+        &target_type,
+        &req.source_id,
+        &req.target_id,
+    )
+    .await
+    {
+        Ok(ids) => ids,
+        Err(e) => return Ok(err_resp(&req.project_path, &e)),
     };
-    let target_id = match resolve_item_type_config(project_path, target_type.as_str()).await {
-        Ok((folder, config)) => {
-            match resolve_item_id(project_path, &folder, &config, &req.target_id).await {
-                Ok(id) => id,
-                Err(e) => return Ok(err_resp(&req.project_path, &e)),
-            }
-        }
-        Err(_) => req.target_id.clone(),
-    };
-
     let custom_types = match read_config(project_path).await {
         Ok(Some(config)) => config.custom_link_types,
         Ok(None) | Err(_) => vec![],

--- a/src/server/handlers/link_create/resolution.rs
+++ b/src/server/handlers/link_create/resolution.rs
@@ -1,0 +1,27 @@
+use crate::item::ItemError;
+use crate::link::TargetType;
+use crate::server::handlers::item_type_resolve::{resolve_item_id, resolve_item_type_config};
+use std::path::Path;
+
+pub(super) async fn resolve_link_ids(
+    project_path: &Path,
+    source_type: &TargetType,
+    target_type: &TargetType,
+    source_id: &str,
+    target_id: &str,
+) -> Result<(String, String), ItemError> {
+    let resolved_source = resolve_one_id(project_path, source_type.as_str(), source_id).await?;
+    let resolved_target = resolve_one_id(project_path, target_type.as_str(), target_id).await?;
+    Ok((resolved_source, resolved_target))
+}
+
+async fn resolve_one_id(
+    project_path: &Path,
+    item_type: &str,
+    raw_id: &str,
+) -> Result<String, ItemError> {
+    match resolve_item_type_config(project_path, item_type).await {
+        Ok((folder, config)) => resolve_item_id(project_path, &folder, &config, raw_id).await,
+        Err(_) => Ok(raw_id.to_string()),
+    }
+}

--- a/src/server/handlers/link_create/validation.rs
+++ b/src/server/handlers/link_create/validation.rs
@@ -1,0 +1,6 @@
+use crate::server::assert_service::{assert_initialized, AssertError};
+use std::path::Path;
+
+pub(super) fn check_initialized(project_path: &Path) -> Result<(), AssertError> {
+    assert_initialized(project_path)
+}


### PR DESCRIPTION
## Summary

- Extract `validation.rs` — initialization check (`assert_initialized`)
- Extract `resolution.rs` — source/target ID resolution (display number → UUID)
- Extract `hooks.rs` — pre-hook execution for link create
- Thin out `mod.rs` to pure orchestration, delegating each concern to the new modules
- `core.rs` unchanged (post-hooks + business logic)

Closes #395

## Test plan

- [x] `cargo build` succeeds with no errors
- [x] All 791 unit tests pass
- [x] All e2e tests pass (112 passed, 25 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)