### PR TITLE
feat(mcp): emit clear error on version mismatch with daemon

### DIFF
--- a/.centy/issues/7c1bed22-afc9-426a-9b9a-dd44aa8ecf14.md
+++ b/.centy/issues/7c1bed22-afc9-426a-9b9a-dd44aa8ecf14.md
@@ -1,10 +1,10 @@
 ---
 # This file is managed by Centy. Use the Centy CLI to modify it.
 displayNumber: 403
-status: open
+status: closed
 priority: 2
 createdAt: 2026-04-12T20:17:31.203612+00:00
-updatedAt: 2026-04-12T20:17:31.203612+00:00
+updatedAt: 2026-04-12T20:31:17.156781+00:00
 ---
 
 # MCP server should emit a clear error when its version is incompatible with the daemon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `centy-mcp` now checks version compatibility with the daemon on startup and emits a clear error if they are incompatible (e.g. `centy-mcp v0.9.2 is incompatible with centy-daemon v0.10.5. Please update centy-mcp.`)
+
 ## [0.12.1] — 2026-04-12
 
 ### Changed

--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Startup version-compatibility check: if `centy-mcp` and the running daemon have different major or minor versions, a human-readable error is printed to stderr and the process exits (e.g. `centy-mcp v0.9.2 is incompatible with centy-daemon v0.10.5. Please update centy-mcp.`). The check is skipped for `dev` builds or when the daemon is unreachable.
+
 ## [0.12.0] — 2026-04-04
 
 ### Added

--- a/mcp/main.go
+++ b/mcp/main.go
@@ -10,6 +10,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
 	"time"
 
 	"connectrpc.com/connect"
@@ -18,6 +20,7 @@ import (
 	"github.com/redpanda-data/protoc-gen-go-mcp/pkg/runtime/mark3labs"
 	"golang.org/x/net/http2"
 
+	centyv1 "github.com/centy-io/centy-daemon/mcp/gen/centy/v1"
 	"github.com/centy-io/centy-daemon/mcp/gen/centy/v1/centyv1connect"
 	"github.com/centy-io/centy-daemon/mcp/gen/centy/v1/centyv1mcp"
 )
@@ -31,6 +34,60 @@ func isDaemonRunning(addr string) bool {
 	}
 	conn.Close()
 	return true
+}
+
+// semverMajorMinor extracts the major and minor integers from a semver string
+// like "1.2.3". Returns (-1, -1, false) if the string is not parseable.
+func semverMajorMinor(v string) (int, int, bool) {
+	v = strings.TrimPrefix(v, "v")
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) < 2 {
+		return -1, -1, false
+	}
+	major, err1 := strconv.Atoi(parts[0])
+	minor, err2 := strconv.Atoi(parts[1])
+	if err1 != nil || err2 != nil {
+		return -1, -1, false
+	}
+	return major, minor, true
+}
+
+// checkDaemonCompatibility calls GetDaemonInfo and exits with a clear error if
+// the daemon version is incompatible with this MCP server version.
+// Compatibility policy: major and minor versions must match.
+// The check is skipped when either version is "dev" or when the daemon is unreachable.
+func checkDaemonCompatibility(client centyv1connect.CentyDaemonClient, mcpVersion string) {
+	if mcpVersion == "dev" {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	resp, err := client.GetDaemonInfo(ctx, connect.NewRequest(&centyv1.GetDaemonInfoRequest{}))
+	if err != nil {
+		// Daemon unreachable — skip version check, tools will fail gracefully at call time.
+		return
+	}
+
+	daemonVersion := resp.Msg.GetVersion()
+	if daemonVersion == "dev" {
+		return
+	}
+
+	mcpMaj, mcpMin, mcpOK := semverMajorMinor(mcpVersion)
+	daeMaj, daeMin, daeOK := semverMajorMinor(daemonVersion)
+
+	if !mcpOK || !daeOK {
+		return
+	}
+
+	if mcpMaj != daeMaj || mcpMin != daeMin {
+		fmt.Fprintf(os.Stderr,
+			"centy-mcp v%s is incompatible with centy-daemon v%s. Please update centy-mcp.\n",
+			mcpVersion, daemonVersion)
+		os.Exit(1)
+	}
 }
 
 func findDaemonBinary() (string, error) {
@@ -70,6 +127,8 @@ func main() {
 		"http://"+addr,
 		connect.WithGRPC(),
 	)
+
+	checkDaemonCompatibility(client, version)
 
 	raw, s := mark3labs.NewServer("centy-daemon", version)
 	centyv1mcp.ForwardToConnectCentyDaemonClient(s, client)


### PR DESCRIPTION
## Summary

- On startup, `centy-mcp` calls `GetDaemonInfo` to compare its own version against the running daemon's version
- If major or minor versions differ, a human-readable error is printed to stderr and the process exits before serving any tools: `centy-mcp v0.9.2 is incompatible with centy-daemon v0.10.5. Please update centy-mcp.`
- Compatibility policy: major **and** minor versions must match (strict for pre-1.0 releases)
- The check is gracefully skipped for `dev` builds or when the daemon is unreachable

Closes #403

## Test plan

- [ ] Build `centy-mcp` at version `0.9.x`, run against a `0.10.x` daemon — verify error message appears on stderr and process exits 1
- [ ] Build both at the same minor — verify server starts normally
- [ ] Build with `version=dev` — verify server starts without checking
- [ ] Shut down the daemon, start `centy-mcp` — verify server starts (skips check when unreachable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)