### PR TITLE
build(lint-staged): extract config to .lintstagedrc.mjs

### DIFF
--- a/.centy/issues/56baf7a8-6a4a-427b-9bd0-6bc90bd20a4d.md
+++ b/.centy/issues/56baf7a8-6a4a-427b-9bd0-6bc90bd20a4d.md
@@ -1,10 +1,10 @@
 ---
 # This file is managed by Centy. Use the Centy CLI to modify it.
 displayNumber: 406
-status: in-progress
+status: closed
 priority: 3
 createdAt: 2026-04-12T21:30:53.493866+00:00
-updatedAt: 2026-04-12T21:32:13.919187+00:00
+updatedAt: 2026-04-12T21:34:11.022540+00:00
 ---
 
 # Extract lint-staged config to its own file

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,0 +1,3 @@
+export default {
+  "*.{rs,md,toml,yml,yaml,json,ts,js,sh,txt}": "cspell --no-progress",
+};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Pre-commit hook now uses `lint-staged` to run `cspell` only on staged files, replacing the manual `git diff --cached` + `xargs` approach
+- Extracted `lint-staged` configuration from `package.json` into a dedicated `.lintstagedrc.mjs` file
 
 ## [0.12.1] — 2026-04-12
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,5 @@
     "husky": "^9.0.0",
     "lint-staged": "^15.0.0"
   },
-  "lint-staged": {
-    "*.{rs,md,toml,yml,yaml,json,ts,js,sh,txt}": "cspell --no-progress"
-  },
   "packageManager": "pnpm@10.21.0"
 }


### PR DESCRIPTION
## Summary
- Extracted the `lint-staged` configuration from `package.json` into a dedicated `.lintstagedrc.mjs` file
- Removed the inline `lint-staged` entry from `package.json` to keep it lean
- Used `.mjs` extension to match the project convention (e.g. `commitlint.config.mjs`)

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)