### PR TITLE
feat(plugin): add Claude Code plugin marketplace for centy-daemon

### DIFF
--- a/.centy/issues/5cba2187-cf55-4d2a-8b18-63e934874318.md
+++ b/.centy/issues/5cba2187-cf55-4d2a-8b18-63e934874318.md
@@ -1,10 +1,10 @@
 ---
 # This file is managed by Centy. Use the Centy CLI to modify it.
 displayNumber: 411
-status: open
+status: closed
 priority: 2
 createdAt: 2026-04-12T22:00:27.997644+00:00
-updatedAt: 2026-04-12T22:00:27.997644+00:00
+updatedAt: 2026-04-13T15:46:14.224748+00:00
 ---
 
 # Implement Claude Code plugin marketplace for centy-daemon

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    {
+      "name": "centy",
+      "description": "Skills for installing centy-daemon and interacting with the Centy MCP server from Claude Code",
+      "path": "./plugins/centy"
+    }
+  ]
+}

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -1,0 +1,118 @@
+name: Validate Plugins
+
+on:
+  push:
+    paths:
+      - '.claude-plugin/**'
+      - 'plugins/**'
+  pull_request:
+    paths:
+      - '.claude-plugin/**'
+      - 'plugins/**'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate marketplace manifest
+        run: |
+          echo "Checking .claude-plugin/marketplace.json..."
+          if [ ! -f .claude-plugin/marketplace.json ]; then
+            echo "ERROR: .claude-plugin/marketplace.json not found"
+            exit 1
+          fi
+          python3 -c "import json, sys; json.load(open('.claude-plugin/marketplace.json'))"
+          echo "marketplace.json is valid JSON"
+
+      - name: Validate plugin manifests
+        run: |
+          for plugin_dir in plugins/*/; do
+            name=$(basename "$plugin_dir")
+            manifest="$plugin_dir.claude-plugin/plugin.json"
+
+            echo "Checking plugin: $name"
+
+            if [ ! -f "$manifest" ]; then
+              echo "ERROR: $manifest not found"
+              exit 1
+            fi
+
+            python3 -c "import json, sys; json.load(open('$manifest'))"
+            echo "  $manifest is valid JSON"
+
+            python3 - <<'EOF'
+import json, sys
+
+manifest_path = "$manifest"
+data = json.load(open(manifest_path))
+
+required = ["name", "version", "description", "skills"]
+for field in required:
+    if field not in data:
+        print(f"ERROR: missing required field '{field}' in {manifest_path}")
+        sys.exit(1)
+
+for skill in data["skills"]:
+    for sf in ["name", "path"]:
+        if sf not in skill:
+            print(f"ERROR: skill entry missing '{sf}' in {manifest_path}")
+            sys.exit(1)
+
+print(f"  plugin.json fields OK: {list(data.keys())}")
+EOF
+          done
+
+      - name: Validate skill SKILL.md files
+        run: |
+          for plugin_dir in plugins/*/; do
+            manifest="$plugin_dir.claude-plugin/plugin.json"
+            if [ ! -f "$manifest" ]; then
+              continue
+            fi
+
+            python3 - "$plugin_dir" "$manifest" <<'EOF'
+import json, sys, os
+
+plugin_dir = sys.argv[1]
+manifest_path = sys.argv[2]
+data = json.load(open(manifest_path))
+
+for skill in data["skills"]:
+    skill_path = os.path.join(plugin_dir, skill["path"].lstrip("./"), "SKILL.md")
+    if not os.path.isfile(skill_path):
+        print(f"ERROR: SKILL.md not found at {skill_path}")
+        sys.exit(1)
+    size = os.path.getsize(skill_path)
+    if size == 0:
+        print(f"ERROR: SKILL.md is empty at {skill_path}")
+        sys.exit(1)
+    print(f"  skill '{skill['name']}': SKILL.md present ({size} bytes)")
+
+print("All skills valid")
+EOF
+          done
+
+      - name: Verify marketplace entries match plugin directories
+        run: |
+          python3 - <<'EOF'
+import json, os, sys
+
+marketplace = json.load(open(".claude-plugin/marketplace.json"))
+errors = []
+
+for entry in marketplace["plugins"]:
+    plugin_path = entry.get("path", "")
+    resolved = plugin_path.lstrip("./")
+    manifest = os.path.join(resolved, ".claude-plugin", "plugin.json")
+    if not os.path.isfile(manifest):
+        errors.append(f"marketplace.json references '{plugin_path}' but {manifest} not found")
+
+if errors:
+    for e in errors:
+        print(f"ERROR: {e}")
+    sys.exit(1)
+
+print(f"All {len(marketplace['plugins'])} marketplace entries are consistent")
+EOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Claude Code plugin marketplace scaffold: users can now install the `centy` plugin via `/plugin marketplace add centy-io/centy-daemon`
+- `plugins/centy/skills/install/SKILL.md` — guided install skill (clone → build → start daemon → register MCP server)
+- `plugins/centy/skills/mcp-usage/SKILL.md` — MCP tools reference skill covering daemon lifecycle, CRUD operations, query language, and common workflows
+- `plugins/centy/.mcp.json` — auto-wires `centy-mcp` when the plugin is installed
+- `.github/workflows/validate-plugins.yml` — CI workflow that validates plugin JSON manifests and SKILL.md presence
+
 ## [0.12.2] — 2026-04-13
 
 ### Added

--- a/cspell.json
+++ b/cspell.json
@@ -248,6 +248,9 @@
     "librdkafka",
     "rskafka",
     "Getenv",
-    "Fprintln"
+    "Fprintln",
+    "lstrip",
+    "isfile",
+    "getsize"
   ]
 }

--- a/plugins/centy/.claude-plugin/plugin.json
+++ b/plugins/centy/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "centy",
+  "version": "1.0.0",
+  "description": "Install and use centy-daemon — the local-first, file-based project management engine for Claude Code",
+  "skills": [
+    {
+      "name": "install",
+      "description": "Walk through cloning, building, and wiring up centy-daemon as an MCP server in Claude Code",
+      "path": "./skills/install"
+    },
+    {
+      "name": "mcp-usage",
+      "description": "Reference guide for all Centy MCP tools, daemon lifecycle, and common workflows",
+      "path": "./skills/mcp-usage"
+    }
+  ]
+}

--- a/plugins/centy/.mcp.json
+++ b/plugins/centy/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "centy": {
+      "command": "npx",
+      "args": ["-y", "centy-mcp"]
+    }
+  }
+}

--- a/plugins/centy/skills/install/SKILL.md
+++ b/plugins/centy/skills/install/SKILL.md
@@ -1,0 +1,110 @@
+# Install centy-daemon
+
+Guide the user step-by-step through setting up `centy-daemon` locally and wiring it up as an MCP server inside Claude Code. Work through each step in order, confirming success before moving on. If a step fails, diagnose and fix before continuing.
+
+## Prerequisites check
+
+Before starting, verify the user has the required tools:
+
+```bash
+rustc --version   # needs 1.85+
+cargo --version
+git --version
+```
+
+If Rust is missing, direct them to https://rustup.rs and wait for confirmation.
+
+## Step 1 — Clone the repository
+
+```bash
+git clone https://github.com/centy-io/centy-daemon.git
+cd centy-daemon
+```
+
+## Step 2 — Build the daemon binary
+
+```bash
+cargo build --release
+```
+
+This places the binary at `target/release/centy-daemon`. The build takes a few minutes on first run.
+
+## Step 3 — Install the binary (optional but recommended)
+
+Make the daemon available system-wide by copying it to a directory on `$PATH`:
+
+```bash
+# macOS / Linux
+cp target/release/centy-daemon ~/.local/bin/centy-daemon
+# or
+sudo cp target/release/centy-daemon /usr/local/bin/centy-daemon
+```
+
+Alternatively, set `CENTY_DAEMON_PATH` to the absolute path of the binary and skip this step.
+
+## Step 4 — Start the daemon
+
+```bash
+# Runs in the foreground on 127.0.0.1:50051
+centy-daemon
+
+# Run as a background process on login (launchd / systemd / any process manager)
+# For a quick test, just run it in a separate terminal tab
+```
+
+Verify it is running:
+
+```bash
+grpcurl -plaintext 127.0.0.1:50051 list   # should print centy.CentyDaemon
+```
+
+## Step 5 — Register the MCP server in Claude Code
+
+Add the following block to the project's `.mcp.json` (or to `~/.claude/mcp.json` for global access):
+
+```json
+{
+  "mcpServers": {
+    "centy": {
+      "command": "npx",
+      "args": ["-y", "centy-mcp"]
+    }
+  }
+}
+```
+
+`centy-mcp` is the official MCP bridge. It connects to the running daemon at `127.0.0.1:50051` and exposes every daemon RPC as a Claude Code tool.
+
+If the daemon listens on a non-default address, set the environment variable:
+
+```json
+{
+  "mcpServers": {
+    "centy": {
+      "command": "npx",
+      "args": ["-y", "centy-mcp"],
+      "env": {
+        "CENTY_DAEMON_ADDR": "127.0.0.1:9090"
+      }
+    }
+  }
+}
+```
+
+## Step 6 — Verify the integration
+
+Restart Claude Code (or reload the MCP servers) then confirm the tools are available:
+
+- Run `/mcp` in Claude Code — you should see the `centy` server listed.
+- Ask Claude to call `IsRunning` — it should report the daemon address.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `centy-mcp` connection refused | Make sure `centy-daemon` is running (`centy-daemon &`) |
+| Binary not found | Set `CENTY_DAEMON_PATH=/absolute/path/to/centy-daemon` in the MCP env block |
+| Version mismatch error in MCP logs | Run `cargo build --release` again; rebuild `centy-mcp` if you changed the proto |
+| `rustc --version` too old | Run `rustup update stable` |
+
+Once complete, tell the user they are ready to use Centy. Suggest running the `mcp-usage` skill to learn about available tools.

--- a/plugins/centy/skills/mcp-usage/SKILL.md
+++ b/plugins/centy/skills/mcp-usage/SKILL.md
@@ -1,0 +1,121 @@
+# Centy MCP Usage
+
+Reference guide for working with the Centy MCP server from within Claude Code. Use this skill when the user asks how to manage issues, start/stop the daemon, or perform any Centy operation via Claude.
+
+## Daemon lifecycle
+
+The MCP server (`centy-mcp`) exposes two lifecycle tools that do not require the daemon to already be running:
+
+| Tool | Description |
+|------|-------------|
+| `IsRunning` | Returns whether `centy-daemon` is currently listening on the configured address |
+| `StartDaemon` | Spawns the daemon as a background process if it is not already running |
+
+**Typical pattern** — always call `IsRunning` first, then `StartDaemon` if needed, before calling any other tool:
+
+```
+IsRunning → (if not running) StartDaemon → <desired tool>
+```
+
+## Core operations
+
+### Projects
+
+| Tool | Key inputs | Notes |
+|------|-----------|-------|
+| `InitializeProject` | `project_path` | Creates the `.centy/` directory and initial config |
+| `IsInitialized` | `project_path` | Check before any project-scoped operation |
+| `GetProjectConfig` | `project_path` | Read schema, field definitions, defaults |
+| `UpdateProjectConfig` | `project_path`, config fields | Update field definitions |
+
+### Issues
+
+| Tool | Key inputs |
+|------|-----------|
+| `CreateItem` (type `issues`) | `project_path`, `title`, optional `status`, `priority`, `body` |
+| `GetItem` (type `issues`) | `project_path`, `item_id` |
+| `UpdateItem` (type `issues`) | `project_path`, `item_id`, fields to change |
+| `DeleteItem` (type `issues`) | `project_path`, `item_id` |
+| `ListItems` (type `issues`) | `project_path`, optional `query` |
+| `SearchItems` (type `issues`) | `project_path`, `query` |
+
+> **Important**: pass `item_type` as `"issues"` (plural), not `"issue"`.
+
+### Query language
+
+Use the `query` parameter on `ListItems` / `SearchItems` with Centy's query syntax:
+
+```
+status = "open"
+status = "open" AND priority >= 2
+title ~ "auth*"          # wildcard
+body ~ /grpc/i           # regex
+status != "closed"
+```
+
+### Links
+
+| Tool | Description |
+|------|-------------|
+| `CreateLink` | Create a bidirectional relationship between two items |
+| `GetLinks` | List all links for an item |
+| `DeleteLink` | Remove a specific link |
+
+### Registry (multi-project)
+
+| Tool | Description |
+|------|-------------|
+| `RegisterProject` | Add a project to the daemon's global registry |
+| `UnregisterProject` | Remove a project from the registry |
+| `ListProjects` | List all registered projects |
+
+### Workspaces
+
+Workspaces are temporary scoped environments used by Claude Code sessions.
+
+| Tool | Description |
+|------|-------------|
+| `CreateWorkspace` | Open a workspace for the current session |
+| `GetWorkspace` | Retrieve an existing workspace |
+| `DeleteWorkspace` | Close and clean up a workspace |
+
+## Common workflows
+
+### Create a new issue
+
+```
+1. IsRunning (start daemon if needed)
+2. IsInitialized { project_path } (init if needed)
+3. CreateItem { item_type: "issues", project_path, title: "...", body: "..." }
+4. GetItem { item_type: "issues", project_path, item_id: <returned id> }
+```
+
+### Close an issue
+
+```
+UpdateItem { item_type: "issues", project_path, item_id, status: "closed" }
+```
+
+### List open high-priority issues
+
+```
+ListItems { item_type: "issues", project_path, query: "status = \"open\" AND priority >= 2" }
+```
+
+### Link two issues
+
+```
+CreateLink { project_path, source_id: "abc", target_id: "xyz", link_type: "blocks" }
+```
+
+## Configuration tips
+
+- The `.centy/config.json` file holds item type definitions and field schemas.
+- Use `GetProjectConfig` to inspect the current schema before creating custom fields.
+- Custom statuses and priorities are defined per-project in `config.json`.
+
+## Getting help
+
+- Run the `install` skill if the daemon is not yet set up.
+- Inspect `.centy/` in any initialized project to see the raw Markdown records.
+- All records are human-readable `.md` files with YAML frontmatter — safe to read and diff in git.


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/marketplace.json` so users can install via `/plugin marketplace add centy-io/centy-daemon`
- `plugins/centy/.claude-plugin/plugin.json` — plugin manifest with two skills
- `plugins/centy/skills/install/SKILL.md` — step-by-step install guide (clone → build → start daemon → wire MCP server in Claude Code)
- `plugins/centy/skills/mcp-usage/SKILL.md` — MCP tools reference covering daemon lifecycle, CRUD operations, query language, and common workflows
- `plugins/centy/.mcp.json` — auto-wires `centy-mcp` when the plugin is installed
- `.github/workflows/validate-plugins.yml` — CI that validates JSON manifests and SKILL.md presence

Closes #411

## Test plan

- [ ] Verify `.claude-plugin/marketplace.json` is valid JSON and references the correct plugin path
- [ ] Verify `plugins/centy/.claude-plugin/plugin.json` has all required fields (name, version, description, skills)
- [ ] Verify `plugins/centy/skills/install/SKILL.md` covers clone → build → start → MCP registration steps
- [ ] Verify `plugins/centy/skills/mcp-usage/SKILL.md` covers all key MCP tools and common workflows
- [ ] CI `validate-plugins.yml` workflow passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)