### PR TITLE
chore: release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] — 2026-04-29
+
 ### Changed
 - Items no longer expose an `updated_at` timestamp via the API. `GenericItemMetadata.updated_at` (proto field 5) is reserved, and `IssueMetadataFlat` no longer carries it. The on-disk YAML still writes `updatedAt` (set to `created_at`) for upstream `mdstore::Frontmatter` compatibility, but the value is no longer refreshed on update or surfaced through gRPC.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "centy-daemon"
-version = "0.12.4"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "centy-daemon"
-version = "0.12.4"
+version = "0.14.0"
 edition = "2021"
 description = "A file-based database engine that stores structured data as Markdown files with YAML frontmatter, exposed via gRPC"
 authors = ["Centy Team"]


### PR DESCRIPTION
## Summary
- Bump \`centy-daemon\` to 0.14.0.
- Promote unreleased CHANGELOG entries under \`[0.14.0] — 2026-04-29\`.
- Breaking: items no longer expose \`updated_at\` via the API (#280).

## Test plan
- [x] cargo build
- [x] CHANGELOG updated