### PR TITLE
fix: prevent nested .centy/.centy folder when init runs inside org repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `get_centy_path` no longer creates a nested `.centy/.centy` folder when `centy init` is run from inside an org's `.centy` repo
+
 ### Changed
 - Upgrade mdstore to 1.0.0 with native frontmatter comment injection (#259)
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -16,8 +16,19 @@ pub const MANIFEST_FILE: &str = ".centy-manifest.json";
 pub const CENTY_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Get the path to the .centy folder
+///
+/// If `project_path` already points to a `.centy` directory (e.g. when the user
+/// runs `centy init` from inside an org's `.centy` repo), return it as-is to
+/// avoid creating a nested `.centy/.centy` structure.
 #[must_use]
 pub fn get_centy_path(project_path: &Path) -> std::path::PathBuf {
+    if project_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n == CENTY_FOLDER)
+    {
+        return project_path.to_path_buf();
+    }
     project_path.join(CENTY_FOLDER)
 }
 

--- a/src/utils/utils_tests_1.rs
+++ b/src/utils/utils_tests_1.rs
@@ -61,6 +61,26 @@ fn test_get_centy_path_relative() {
 }
 
 #[test]
+fn test_get_centy_path_already_centy_folder() {
+    let project_path = Path::new("/home/user/org/.centy");
+    let centy_path = get_centy_path(project_path);
+
+    assert_eq!(centy_path, Path::new("/home/user/org/.centy"));
+    assert_ne!(centy_path, Path::new("/home/user/org/.centy/.centy"));
+}
+
+#[test]
+fn test_get_manifest_path_already_centy_folder() {
+    let project_path = Path::new("/home/user/org/.centy");
+    let manifest_path = get_manifest_path(project_path);
+
+    assert_eq!(
+        manifest_path,
+        Path::new("/home/user/org/.centy/.centy-manifest.json")
+    );
+}
+
+#[test]
 fn test_paths_are_consistent() {
     let project_path = Path::new("/test");
     let centy_path = get_centy_path(project_path);


### PR DESCRIPTION
Fixes #282

## Summary

- `get_centy_path` unconditionally appended `.centy` to `project_path`, creating `<org>/.centy/.centy` when `centy init` was run from inside an org's `.centy` repo
- Now returns `project_path` as-is when its final component is already `.centy`

## Test plan

- [ ] `test_get_centy_path_already_centy_folder` — new unit test verifying no nesting
- [ ] `test_get_manifest_path_already_centy_folder` — manifest path still correct when project_path is `.centy`
- [ ] All existing `get_centy_path` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)