### PR TITLE
fix: init creates nested .centy/.centy folder when run inside a .centy repo

### DIFF
--- a/daemon/src/utils/mod.rs
+++ b/daemon/src/utils/mod.rs
@@ -15,9 +15,16 @@ pub const MANIFEST_FILE: &str = ".centy-manifest.json";
 /// Current centy version (from Cargo.toml)
 pub const CENTY_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-/// Get the path to the .centy folder
+/// Get the path to the .centy folder.
+///
+/// If `project_path` is itself a `.centy` directory (e.g. running inside an
+/// org's `.centy` repo), it is used as-is rather than nesting another
+/// `.centy` inside it.
 #[must_use]
 pub fn get_centy_path(project_path: &Path) -> std::path::PathBuf {
+    if project_path.file_name().and_then(|name| name.to_str()) == Some(CENTY_FOLDER) {
+        return project_path.to_path_buf();
+    }
     project_path.join(CENTY_FOLDER)
 }
 

--- a/daemon/src/utils/path_utilities.rs
+++ b/daemon/src/utils/path_utilities.rs
@@ -61,6 +61,27 @@ fn test_get_centy_path_relative() {
 }
 
 #[test]
+fn test_get_centy_path_already_centy_dir() {
+    // Running inside an org's `.centy` repo: the path is used as-is rather
+    // than nesting `.centy/.centy`.
+    let project_path = Path::new("/home/user/my-org/.centy");
+    let centy_path = get_centy_path(project_path);
+
+    assert_eq!(centy_path, Path::new("/home/user/my-org/.centy"));
+}
+
+#[test]
+fn test_get_manifest_path_already_centy_dir() {
+    let project_path = Path::new("/home/user/my-org/.centy");
+    let manifest_path = get_manifest_path(project_path);
+
+    assert_eq!(
+        manifest_path,
+        Path::new("/home/user/my-org/.centy/.centy-manifest.json")
+    );
+}
+
+#[test]
 fn test_paths_are_consistent() {
     let project_path = Path::new("/test");
     let centy_path = get_centy_path(project_path);


### PR DESCRIPTION
## Problem

Running `centy init` from inside an org's `.centy` repo (e.g. `<org>/.centy/`) created a nested `.centy/.centy` structure instead of reusing the existing directory.

## Root cause

`get_centy_path` in `daemon/src/utils/mod.rs` unconditionally appended `.centy` to `project_path`, so when `project_path` was already `<org>/.centy`, it produced `<org>/.centy/.centy`.

## Fix

Detect when `project_path` is itself a `.centy` directory (its final component equals `CENTY_FOLDER`) and return it as-is. Since every other path helper (`get_manifest_path`, etc.) routes through `get_centy_path`, this fixes the whole class at the single chokepoint.

## Tests

Added regression tests:
- `test_get_centy_path_already_centy_dir`
- `test_get_manifest_path_already_centy_dir`

Checks run locally:
- `cargo test` (utils path tests) → pass
- `cargo clippy -p centy-daemon` → clean

Closes #282