### PR TITLE
fix(link): honor type: prefix in link source/target arguments

### DIFF
--- a/daemon/src/server/handlers/link_create/mod.rs
+++ b/daemon/src/server/handlers/link_create/mod.rs
@@ -44,14 +44,16 @@ pub async fn create_link(req: CreateLinkRequest) -> Result<Response<CreateLinkRe
     {
         return Ok(err_resp(&req.project_path, &e));
     }
-    let source_type = TargetType::new(req.source_item_type.to_lowercase());
-    let target_type = TargetType::new(req.target_item_type.to_lowercase());
+    let (source_type_str, source_id_arg) = split_type_prefix(&req.source_item_type, &req.source_id);
+    let (target_type_str, target_id_arg) = split_type_prefix(&req.target_item_type, &req.target_id);
+    let source_type = TargetType::new(source_type_str.to_lowercase());
+    let target_type = TargetType::new(target_type_str.to_lowercase());
     let (source_id, target_id) = match resolution::resolve_link_ids(
         project_path,
         &source_type,
         &target_type,
-        &req.source_id,
-        &req.target_id,
+        &source_id_arg,
+        &target_id_arg,
     )
     .await
     {
@@ -79,4 +81,63 @@ pub async fn create_link(req: CreateLinkRequest) -> Result<Response<CreateLinkRe
         &req.project_path,
     )
     .await
+}
+
+/// Parse an optional `type:id` prefix from a link source/target argument.
+///
+/// Link sources and targets may be given as `type:id` (e.g. `plan:1` or
+/// `plan:<uuid>`) so items can be linked across types. When a prefix is
+/// present the embedded type overrides `default_type` and the remaining `id`
+/// is returned. UUIDs and display numbers never contain a colon, so a `:`
+/// unambiguously marks a type prefix. Returns `(type, id)`.
+fn split_type_prefix(default_type: &str, raw: &str) -> (String, String) {
+    match raw.split_once(':') {
+        Some((ty, id)) if !ty.is_empty() && !id.is_empty() => (ty.to_string(), id.to_string()),
+        _ => (default_type.to_string(), raw.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod split_type_prefix_tests {
+    use super::split_type_prefix;
+
+    #[test]
+    fn no_prefix_keeps_default_type() {
+        assert_eq!(
+            split_type_prefix("issue", "1"),
+            ("issue".to_string(), "1".to_string())
+        );
+        let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        assert_eq!(
+            split_type_prefix("issue", uuid),
+            ("issue".to_string(), uuid.to_string())
+        );
+    }
+
+    #[test]
+    fn prefix_overrides_default_type() {
+        assert_eq!(
+            split_type_prefix("issue", "plan:1"),
+            ("plan".to_string(), "1".to_string())
+        );
+        assert_eq!(
+            split_type_prefix("issue", "plan:bbbbbbbb-1111-2222-3333-444444444444"),
+            (
+                "plan".to_string(),
+                "bbbbbbbb-1111-2222-3333-444444444444".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn malformed_prefix_falls_back_to_default() {
+        assert_eq!(
+            split_type_prefix("issue", ":1"),
+            ("issue".to_string(), ":1".to_string())
+        );
+        assert_eq!(
+            split_type_prefix("issue", "plan:"),
+            ("issue".to_string(), "plan:".to_string())
+        );
+    }
 }


### PR DESCRIPTION
## Problem

Link sources and targets can be given as `type:id` (e.g. `plan:1` or `plan:<uuid>`) to link across item types. The `link_create` handler ignored the `type:` prefix and always resolved the id against the item type taken from the request, so cross-type linking failed:

- **#239** — `centy link issue <uuid> relates-to plan:<uuid>` → `Target entity not found: <uuid> (issue)`. The `plan:` prefix was dropped and the target UUID was looked up under the source type.
- **#238** — when an issue and a plan both have `displayNumber: 1`, `centy link plan 1 relates-to issue:1` resolved both sides to the same entity (the prefix on `issue:1` was ignored, so both used the `plan` type), raising a false `SELF_LINK`.

Both bugs share one root cause: the `type:` prefix was never parsed.

## Fix

Parse the optional `type:` prefix from the source and target arguments in the `link_create` handler and use the embedded type to override the default before resolution. UUIDs and display numbers never contain a colon, so a `:` unambiguously marks a type prefix.

Display-number lookup (`generic_get_by_display_number`) is already type-scoped, so once the correct type flows through, `plan:1` and `issue:1` resolve to distinct entities and the false `SELF_LINK` disappears.

## Tests

- Added unit tests for the new `split_type_prefix` helper (no-prefix fallthrough, prefix override with display number and UUID, malformed prefixes fall back to default).
- `cargo test -p centy-daemon --lib link` → 77 passed, no regressions.
- `cargo clippy -p centy-daemon` → clean.

Closes #239
Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)