### PR TITLE
fix(link): honor type prefix on link target ids (cross-type linking)

### DIFF
--- a/daemon/src/server/handlers/link_create/mod.rs
+++ b/daemon/src/server/handlers/link_create/mod.rs
@@ -44,12 +44,12 @@ pub async fn create_link(req: CreateLinkRequest) -> Result<Response<CreateLinkRe
     {
         return Ok(err_resp(&req.project_path, &e));
     }
-    let source_type = TargetType::new(req.source_item_type.to_lowercase());
-    let target_type = TargetType::new(req.target_item_type.to_lowercase());
-    let (source_id, target_id) = match resolution::resolve_link_ids(
+    let default_source_type = TargetType::new(req.source_item_type.to_lowercase());
+    let default_target_type = TargetType::new(req.target_item_type.to_lowercase());
+    let (source_id, source_type, target_id, target_type) = match resolution::resolve_link_ids(
         project_path,
-        &source_type,
-        &target_type,
+        &default_source_type,
+        &default_target_type,
         &req.source_id,
         &req.target_id,
     )

--- a/daemon/src/server/handlers/link_create/resolution.rs
+++ b/daemon/src/server/handlers/link_create/resolution.rs
@@ -3,16 +3,52 @@ use crate::link::TargetType;
 use crate::server::handlers::item_type_resolve::{resolve_item_id, resolve_item_type_config};
 use std::path::Path;
 
+/// Resolve the source and target IDs (and their effective types) for a link.
+///
+/// Either ID may carry an optional `type:` prefix (e.g. `plan:<uuid>`). When the
+/// prefix names a known item type, it overrides the default type for that side,
+/// which is what makes cross-type linking by full UUID possible. When there is
+/// no prefix — or the prefix is not a recognized item type — the default type is
+/// used and the raw value is treated as the ID unchanged.
 pub(super) async fn resolve_link_ids(
     project_path: &Path,
     source_type: &TargetType,
     target_type: &TargetType,
     source_id: &str,
     target_id: &str,
-) -> Result<(String, String), ItemError> {
-    let resolved_source = resolve_one_id(project_path, source_type.as_str(), source_id).await?;
-    let resolved_target = resolve_one_id(project_path, target_type.as_str(), target_id).await?;
-    Ok((resolved_source, resolved_target))
+) -> Result<(String, TargetType, String, TargetType), ItemError> {
+    let (resolved_source_id, resolved_source_type) =
+        resolve_side(project_path, source_type, source_id).await?;
+    let (resolved_target_id, resolved_target_type) =
+        resolve_side(project_path, target_type, target_id).await?;
+    Ok((
+        resolved_source_id,
+        resolved_source_type,
+        resolved_target_id,
+        resolved_target_type,
+    ))
+}
+
+/// Resolve one side of a link, honoring an optional `type:` prefix on `raw_id`.
+///
+/// Returns the resolved ID and the type that should be used for it.
+async fn resolve_side(
+    project_path: &Path,
+    default_type: &TargetType,
+    raw_id: &str,
+) -> Result<(String, TargetType), ItemError> {
+    if let Some((prefix, rest)) = raw_id.split_once(':') {
+        if !prefix.is_empty() && !rest.is_empty() {
+            // Only treat the prefix as a type override when it actually names a
+            // configured/built-in item type; otherwise it is part of the ID.
+            if let Ok((folder, config)) = resolve_item_type_config(project_path, prefix).await {
+                let id = resolve_item_id(project_path, &folder, &config, rest).await?;
+                return Ok((id, TargetType::new(prefix.to_lowercase())));
+            }
+        }
+    }
+    let id = resolve_one_id(project_path, default_type.as_str(), raw_id).await?;
+    Ok((id, default_type.clone()))
 }
 
 async fn resolve_one_id(

--- a/daemon/tests/link_test.rs
+++ b/daemon/tests/link_test.rs
@@ -1090,3 +1090,72 @@ async fn test_link_nonexistent_slug_story_returns_not_found() {
         "Expected TargetNotFound, got {err:?}"
     );
 }
+
+/// Regression test for #239: a `type:` prefix on the link TARGET must resolve
+/// the entity using the prefixed type, even when the request's target item type
+/// defaults to the source type. Mirrors `centy link issue <id> relates-to
+/// story:<id>`, where the CLI sends the target type defaulted to the source.
+#[tokio::test]
+async fn test_create_link_target_type_prefix_overrides_source_type() {
+    use centy_daemon::server::handlers::link_create::create_link as server_create_link;
+    use centy_daemon::server::proto::CreateLinkRequest;
+
+    let temp_dir = create_test_dir();
+    let project_path = temp_dir.path();
+    init_centy_project(project_path).await;
+
+    let story_config = setup_story_type(project_path).await;
+    let story = generic_create(
+        project_path,
+        "stories",
+        &story_config,
+        CreateOptions {
+            title: "Prefixed Target Story".to_string(),
+            body: String::new(),
+            id: None,
+            status: Some("draft".to_string()),
+            priority: None,
+            tags: None,
+            custom_fields: std::collections::HashMap::new(),
+            comment: None,
+        },
+    )
+    .await
+    .expect("Should create story");
+
+    let issue = create_issue(
+        project_path,
+        CreateIssueOptions {
+            title: "Source Issue".to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("Should create issue");
+
+    // target_item_type defaults to the source type ("issue"); the real type is
+    // carried only by the `story:` prefix on target_id.
+    let req = CreateLinkRequest {
+        project_path: project_path.to_string_lossy().into_owned(),
+        source_item_type: "issue".to_string(),
+        source_id: issue.id.clone(),
+        target_item_type: "issue".to_string(),
+        target_id: format!("story:{}", story.id),
+        link_type: "relates-to".to_string(),
+    };
+
+    let resp = server_create_link(req)
+        .await
+        .expect("handler should return a response")
+        .into_inner();
+
+    assert!(
+        resp.success,
+        "cross-type link via `story:` prefix should succeed, got error: {}",
+        resp.error
+    );
+
+    // The created link should point at the story's real id, resolved as a story.
+    let created = resp.created_link.expect("created_link should be present");
+    assert_eq!(created.target_id, story.id);
+}


### PR DESCRIPTION
## Summary

Closes #239.

When creating a link with a cross-type target given as a full UUID — e.g. `centy link issue <id> relates-to plan:<uuid>` — the `plan:` type prefix on the TARGET was ignored. The daemon resolved the target id using the **source** type, failing with:

```
Target entity not found: <id> (issue)
```

This made cross-type linking by full UUID impossible (the only way to avoid display-number collisions across types).

## Fix

`link_create` now parses an optional `type:` prefix on the target id (and, symmetrically, the source id) in `resolution.rs`:

- If the prefix names a **known item type** (validated against the item-type registry), it overrides the default type for that side and the remainder is resolved as the id.
- Otherwise the value is treated as a plain id, unchanged — so ids without a real type prefix are unaffected.

`mod.rs` now takes the resolved `(id, type)` pairs from the resolver so the overridden type flows into existence checks and the stored link.

## Testing

- New regression test `test_create_link_target_type_prefix_overrides_source_type` drives the server `create_link` handler with a `story:`-prefixed target whose request `target_item_type` defaults to the source type (`issue`) — exactly the issue's scenario. Verified it **fails without the fix** (`Target entity not found: story:... (issue)`) and passes with it.
- `cargo test --test link_test` → 26 passed.
- `cargo clippy --all-targets -p centy-daemon` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)