### PR TITLE
fix(init): reuse existing .centy dir instead of nesting .centy/.centy

### DIFF
--- a/daemon/src/utils/mod.rs
+++ b/daemon/src/utils/mod.rs
@@ -15,9 +15,16 @@ pub const MANIFEST_FILE: &str = ".centy-manifest.json";
 /// Current centy version (from Cargo.toml)
 pub const CENTY_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-/// Get the path to the .centy folder
+/// Get the path to the .centy folder.
+///
+/// Idempotent: when `project_path` is already a `.centy` directory (e.g. an
+/// org's own `.centy` repo, where commands run from inside it), it is returned
+/// as-is instead of nesting a second `.centy/.centy`.
 #[must_use]
 pub fn get_centy_path(project_path: &Path) -> std::path::PathBuf {
+    if project_path.file_name() == Some(std::ffi::OsStr::new(CENTY_FOLDER)) {
+        return project_path.to_path_buf();
+    }
     project_path.join(CENTY_FOLDER)
 }
 

--- a/daemon/src/utils/path_utilities.rs
+++ b/daemon/src/utils/path_utilities.rs
@@ -10,6 +10,27 @@ fn test_get_centy_path() {
 }
 
 #[test]
+fn test_get_centy_path_idempotent_inside_centy_dir() {
+    // Regression for #282: running from inside an org's own `.centy` repo must
+    // not nest a second `.centy/.centy`.
+    let project_path = Path::new("/home/user/my-org/.centy");
+    let centy_path = get_centy_path(project_path);
+
+    assert_eq!(centy_path, Path::new("/home/user/my-org/.centy"));
+}
+
+#[test]
+fn test_get_manifest_path_inside_centy_dir() {
+    let project_path = Path::new("/home/user/my-org/.centy");
+    let manifest_path = get_manifest_path(project_path);
+
+    assert_eq!(
+        manifest_path,
+        Path::new("/home/user/my-org/.centy/.centy-manifest.json")
+    );
+}
+
+#[test]
 fn test_get_manifest_path() {
     let project_path = Path::new("/home/user/my-project");
     let manifest_path = get_manifest_path(project_path);


### PR DESCRIPTION
## Summary

Closes #282.

Running `centy init` from inside an org's own `.centy` repo (e.g. `<org>/.centy/`) created a nested `.centy/.centy/` structure instead of using the existing directory. Root cause: `get_centy_path` in `daemon/src/utils/mod.rs` unconditionally appended `.centy` to the project path, so when the path already ended in `.centy` it produced `<org>/.centy/.centy`.

## Fix

Make `get_centy_path` **idempotent**: when the project path's final component is already `.centy`, return it unchanged; otherwise append as before.

Every centy-path consumer (78 call sites) goes through this single helper, so the fix applies uniformly — `init` no longer nests, and subsequent commands run from inside the `.centy` repo find the managed files in the right place rather than reporting "not initialized". Normal projects (whose paths don't end in `.centy`) are unaffected.

## Testing

- Added `test_get_centy_path_idempotent_inside_centy_dir` and `test_get_manifest_path_inside_centy_dir`.
- `cargo test --lib` → 801 passed.
- `cargo clippy --lib -p centy-daemon` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)