### PR TITLE
chore(lint): enable clippy::redundant_iter_cloned

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -1053,6 +1053,9 @@ get_unwrap = "deny"
 significant_drop_in_scrutinee = "deny"
 single_char_lifetime_names = "deny"
 ref_patterns = "deny"
+# Avoid needless allocations from `.iter().cloned()` where a borrowing
+# iterator adapter would do (e.g. `.iter().cloned().any(..)`)
+redundant_iter_cloned = "deny"
 
 [[bin]]
 name = "centy-daemon"


### PR DESCRIPTION
## What
Enables the `clippy::redundant_iter_cloned` lint at `deny` in `daemon/Cargo.toml`'s `[lints.clippy]` table.

## Why
`redundant_iter_cloned` catches `.iter().cloned()` / `.copied()` chains whose consuming adapter (e.g. `any`, `find`, `count`) only borrows the elements, so the clone is a wasted per-element allocation:

```rust
// flagged
items.iter().cloned().any(|x| x == target)
// preferred
items.iter().any(|x| *x == target)
```

It complements the crate's existing clone-hygiene lints (`cloned_instead_of_copied`, `implicit_clone`) at the iterator level — improving performance and making intentional ownership explicit.

## Impact
- Single-line lint addition (plus an explanatory comment).
- **0** current violations, so no source changes were needed.
- Verified locally:
  - `cargo clippy --all-targets -- -D warnings` ✅ (the CI command)
  - `cargo build` ✅
  - `cargo test` ✅ (all suites pass)

Closes #288