### PR TITLE
fix(utils): avoid nested .centy folder when path already is .centy

### DIFF
--- a/daemon/src/utils/mod.rs
+++ b/daemon/src/utils/mod.rs
@@ -16,8 +16,15 @@ pub const MANIFEST_FILE: &str = ".centy-manifest.json";
 pub const CENTY_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Get the path to the .centy folder
+///
+/// If `project_path` already points at a `.centy` folder (e.g. running inside
+/// an org's `.centy` repo), it is used as-is instead of nesting another
+/// `.centy` inside it.
 #[must_use]
 pub fn get_centy_path(project_path: &Path) -> std::path::PathBuf {
+    if project_path.file_name().and_then(|n| n.to_str()) == Some(CENTY_FOLDER) {
+        return project_path.to_path_buf();
+    }
     project_path.join(CENTY_FOLDER)
 }
 

--- a/daemon/src/utils/path_utilities.rs
+++ b/daemon/src/utils/path_utilities.rs
@@ -10,6 +10,27 @@ fn test_get_centy_path() {
 }
 
 #[test]
+fn test_get_centy_path_already_centy_folder() {
+    // Running inside an org's `.centy` repo should reuse the folder, not nest
+    // another `.centy` inside it (regression for #282).
+    let project_path = Path::new("/home/user/my-org/.centy");
+    let centy_path = get_centy_path(project_path);
+
+    assert_eq!(centy_path, Path::new("/home/user/my-org/.centy"));
+}
+
+#[test]
+fn test_get_manifest_path_already_centy_folder() {
+    let project_path = Path::new("/home/user/my-org/.centy");
+    let manifest_path = get_manifest_path(project_path);
+
+    assert_eq!(
+        manifest_path,
+        Path::new("/home/user/my-org/.centy/.centy-manifest.json")
+    );
+}
+
+#[test]
 fn test_get_manifest_path() {
     let project_path = Path::new("/home/user/my-project");
     let manifest_path = get_manifest_path(project_path);


### PR DESCRIPTION
## Summary

Fixes #282. Running `centy init` from inside an org's `.centy` repo (e.g. `<org>/.centy/`) created a nested `.centy/.centy` structure. Root cause: `get_centy_path` in `daemon/src/utils/mod.rs` unconditionally appended `.centy` to the project path.

## Fix

`get_centy_path` now detects when `project_path` already points at a `.centy` folder and uses it as-is instead of nesting another `.centy` inside it. The fix is centralized in `get_centy_path`, so every caller (`get_manifest_path`, config IO, reconciliation, item-type config, …) behaves consistently. Normal project roots (not named `.centy`) are unaffected.

## Tests

Added two regression tests in `daemon/src/utils/path_utilities.rs`:
- `get_centy_path("<org>/.centy")` → `<org>/.centy` (no nesting)
- `get_manifest_path("<org>/.centy")` → `<org>/.centy/.centy-manifest.json`

`cargo test -p centy-daemon utils::` → 29 passed (incl. new tests). `cargo fmt --check` clean. No new clippy findings introduced by this change.

---
This pull request was opened by the "Open issues → fix PRs (owned repos + my orgs)" routine of moadim.