### PR TITLE
chore: update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Deny three more zero-violation Rust standard lints: `let_underscore_drop`, `dangling_pointers_from_temporaries`, `unnecessary_transmutes`; replace `let _ = result` with `drop(result)` at four call sites for explicit intent
 
+### Fixed
+- Issue #282: `centy init` no longer creates a nested `.centy/.centy` folder when run from inside an org's `.centy` repo — `get_centy_path` now returns `project_path` as-is when its final component is already `.centy` instead of unconditionally appending another `.centy`
+
 ## [0.14.0] — 2026-04-29
 
 ### Changed


### PR DESCRIPTION
Updates the `## [Unreleased]` section of CHANGELOG.md to reflect a merged change that was not yet documented.

## Changes covered
- Added a `### Fixed` entry for the nested `.centy/.centy` folder bug: `centy init` run inside an org's `.centy` repo no longer creates a doubly-nested `.centy/.centy` directory.

## Source PR(s)
- #283 — fix: prevent nested .centy/.centy folder when init runs inside org repo (merged 2026-06-10, fixes issue #282)

No other merged PRs after the v0.14.0 release (#281) were missing; #277–#280 are already documented under 0.14.0. Only the `[Unreleased]` section was edited; released sections are untouched.

This pull request was opened by the CHANGELOG.md keeper (owned repos + my orgs) routine of moadim.