### PR TITLE
fix(organizations): use slug crate for unicode-safe slugify

### DIFF
--- a/daemon/src/registry/organizations/slug.rs
+++ b/daemon/src/registry/organizations/slug.rs
@@ -2,14 +2,7 @@ use super::errors::OrganizationError;
 
 /// Convert a name to a URL-friendly slug (kebab-case)
 pub fn slugify(name: &str) -> String {
-    name.to_lowercase()
-        .chars()
-        .map(|c| if c.is_alphanumeric() { c } else { '-' })
-        .collect::<String>()
-        .split('-')
-        .filter(|s| !s.is_empty())
-        .collect::<Vec<_>>()
-        .join("-")
+    slug::slugify(name)
 }
 
 /// Validate a slug (must be non-empty, lowercase alphanumeric with hyphens)

--- a/daemon/src/registry/organizations/slug_tests.rs
+++ b/daemon/src/registry/organizations/slug_tests.rs
@@ -13,6 +13,19 @@ fn test_slugify() {
 }
 
 #[test]
+fn test_slugify_non_ascii() {
+    // Non-ASCII names must transliterate to a valid (ASCII) slug instead of
+    // passing accented/non-Latin characters through untouched.
+    let slug = slugify("Café Müller");
+    assert!(validate_slug(&slug).is_ok());
+    assert_eq!(slug, "cafe-muller");
+
+    let slug = slugify("Zürich Corp");
+    assert!(validate_slug(&slug).is_ok());
+    assert_eq!(slug, "zurich-corp");
+}
+
+#[test]
 fn test_validate_slug() {
     assert!(validate_slug("valid-slug").is_ok());
     assert!(validate_slug("also-valid-123").is_ok());

--- a/daemon/tests/registry_org_test.rs
+++ b/daemon/tests/registry_org_test.rs
@@ -92,6 +92,22 @@ async fn test_create_organization_auto_slug() {
 }
 
 #[tokio::test]
+async fn test_create_organization_auto_slug_non_ascii_name() {
+    let _lock = acquire_lock();
+    let suffix = unique_slug("cafe");
+    let name = format!("Café Müller {suffix}");
+    let result = create_organization(None, &name, None)
+        .await
+        .expect("Should create org from a non-ASCII name");
+
+    assert_eq!(result.slug, format!("cafe-muller-{suffix}"));
+    assert_eq!(result.name, name);
+
+    // Cleanup
+    drop(delete_organization(&result.slug, false).await);
+}
+
+#[tokio::test]
 async fn test_create_organization_already_exists() {
     let _lock = acquire_lock();
     let slug = unique_slug("dup-test");


### PR DESCRIPTION
## Problem

`slugify()` in `daemon/src/registry/organizations/slug.rs` was hand-rolled: it lowercased and replaced every non-alphanumeric char with `-`. `char::is_alphanumeric()` is Unicode-aware, so accented/non-Latin letters (`é`, `ü`, CJK, Cyrillic, etc.) passed straight through untouched.

The sibling `validate_slug()` only accepts ASCII, and the auto-slug-from-name path (`create_organization` with no explicit slug) runs the generated slug straight through that validator. Result: creating an organization by name only (e.g. `"Café Müller"`) failed with `InvalidSlug`, even though the display name itself was perfectly valid.

## Fix

Replace the hand-rolled body with the `slug` crate's `slug::slugify()`, which transliterates Unicode to ASCII before hyphenating — its output always satisfies the ASCII-only validator. The crate was already a dependency (`slug = "0.1.6"` in `daemon/Cargo.toml`) and already used elsewhere in this codebase (`item_type_create/validate.rs`), so no new dependency is introduced.

## Testing

- Added a unit test (`test_slugify_non_ascii`) covering `"Café Müller"` / `"Zürich Corp"` against both `slugify` and `validate_slug`.
- Added an integration test (`test_create_organization_auto_slug_non_ascii_name`) that creates an organization end-to-end from a non-ASCII name and asserts success.
- `cargo test --all-targets` — 800+ tests pass, no regressions.
- Pre-existing `cargo clippy --all-targets -- -D warnings` failures in unrelated files (`workspace/standalone.rs` etc.) confirmed present on `main` before this change — not touched or worsened here.

Closes #293

---
This pull request was opened by the Open issues → fix PRs (owned repos + my orgs) routine of moadim.