### PR TITLE
fix(cleanup): resolve link endpoint folders via item type registry

### DIFF
--- a/daemon/src/cleanup/cleanup_tests.rs
+++ b/daemon/src/cleanup/cleanup_tests.rs
@@ -284,6 +284,78 @@ async fn test_valid_links_not_removed_by_orphan_cleanup() {
     );
 }
 
+/// A second item type whose folder name is an irregular plural of its type
+/// name ("story" -> "stories", not the naive "storys" you get by appending
+/// "s"). Regression coverage for issue #295: the orphan sweep used to derive
+/// an endpoint's folder with naive pluralization instead of the item type
+/// registry, so cross-type links touching a type like this were wrongly
+/// treated as dangling even though both endpoints existed on disk.
+async fn write_story_type_config(project_path: &std::path::Path) {
+    let mut itc = default_issue_config(&CentyConfig::default());
+    itc.name = "Story".to_string();
+    write_item_type_config(project_path, "stories", &itc)
+        .await
+        .unwrap();
+}
+
+fn story_config() -> TypeConfig {
+    let mut itc = default_issue_config(&CentyConfig::default());
+    itc.name = "Story".to_string();
+    TypeConfig::from(&itc)
+}
+
+async fn create_story(project_path: &std::path::Path, title: &str) -> mdstore::Item {
+    let options = CreateOptions {
+        title: title.to_string(),
+        body: String::new(),
+        id: None,
+        status: Some("open".to_string()),
+        priority: Some(2),
+        tags: None,
+        custom_fields: HashMap::new(),
+        comment: None,
+    };
+    generic_create(project_path, "stories", &story_config(), options)
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn test_valid_cross_type_relates_to_link_survives_orphan_cleanup() {
+    let temp = tempfile::tempdir().unwrap();
+    setup_project(temp.path()).await;
+    write_issue_type_config(temp.path()).await;
+    write_story_type_config(temp.path()).await;
+
+    let issue = create_issue(temp.path(), "Issue A").await;
+    let story = create_story(temp.path(), "Story B").await;
+
+    create_link(
+        temp.path(),
+        CreateLinkOptions {
+            source_id: issue.id.clone(),
+            source_type: TargetType::new("issue"),
+            target_id: story.id.clone(),
+            target_type: TargetType::new("story"),
+            link_type: "relates-to".to_string(),
+        },
+        &[],
+    )
+    .await
+    .unwrap();
+
+    // Both endpoints exist on disk (in "issues/" and "stories/" respectively).
+    clean_orphan_links_for_project(temp.path()).await;
+
+    let links_after = list_all_links(temp.path()).await.unwrap();
+    assert_eq!(
+        links_after.len(),
+        1,
+        "relates-to link between two live items must survive the orphan sweep \
+         even when the target type's folder isn't a naive '+s' plural of its name"
+    );
+}
+
 #[tokio::test]
 async fn test_orphan_links_swept_during_regular_cleanup() {
     let temp = tempfile::tempdir().unwrap();

--- a/daemon/src/cleanup/project.rs
+++ b/daemon/src/cleanup/project.rs
@@ -1,19 +1,34 @@
-use crate::config::item_type_config::discover_item_types_map;
+use crate::config::item_type_config::{discover_item_types_map, ItemTypeRegistry};
 use crate::item::generic::storage::{generic_delete, generic_list};
-use crate::link::{delete_link_by_id, list_all_links};
+use crate::link::{delete_link_by_id, list_all_links, TargetType};
 use crate::utils::get_centy_path;
 use chrono::{DateTime, Duration, Utc};
 use mdstore::{Filters, TypeConfig};
 use std::path::Path;
 use tracing::{debug, error, warn};
 
+/// Resolve an entity type to its actual storage folder using the item type
+/// registry (handles exact folder, case-insensitive name, and case-insensitive
+/// folder matches). Falls back to the naive `folder_name()` (append "s") if
+/// the registry has no matching type — matching the resolution used at link
+/// creation time (see `link::crud_helpers::resolve_folder`).
+fn resolve_folder(registry: Option<&ItemTypeRegistry>, entity_type: &TargetType) -> String {
+    registry
+        .and_then(|r| r.resolve(entity_type.as_str()).map(|(f, _)| f.clone()))
+        .unwrap_or_else(|| entity_type.folder_name())
+}
+
 /// Returns `true` when either the source or the target item file no longer exists on disk.
-fn link_is_orphan(centy_path: &std::path::Path, link: &crate::link::LinkRecord) -> bool {
+fn link_is_orphan(
+    centy_path: &std::path::Path,
+    registry: Option<&ItemTypeRegistry>,
+    link: &crate::link::LinkRecord,
+) -> bool {
     let source_path = centy_path
-        .join(link.source_type.folder_name())
+        .join(resolve_folder(registry, &link.source_type))
         .join(format!("{}.md", link.source_id));
     let target_path = centy_path
-        .join(link.target_type.folder_name())
+        .join(resolve_folder(registry, &link.target_type))
         .join(format!("{}.md", link.target_id));
     !source_path.exists() || !target_path.exists()
 }
@@ -46,8 +61,12 @@ pub async fn clean_orphan_links_for_project(project_path: &Path) {
             return;
         }
     };
+    // Build once and reuse for every link so all configured item-type
+    // directories (not just the naive singular+"s" guess) are considered
+    // when checking whether an endpoint still exists.
+    let registry = ItemTypeRegistry::build(project_path).await.ok();
     for link in links {
-        if link_is_orphan(&centy_path, &link) {
+        if link_is_orphan(&centy_path, registry.as_ref(), &link) {
             remove_orphan_link(project_path, &link).await;
         }
     }


### PR DESCRIPTION
## Root cause

`clean_orphan_links_for_project` (run at daemon startup and hourly via `spawn_cleanup_task`) sweeps `.centy/links/*.md` and hard-deletes any link whose source or target item no longer exists. It decided existence with:

```rust
let source_path = centy_path
    .join(link.source_type.folder_name())   // naive: format!("{}s", type)
    .join(format!("{}.md", link.source_id));
```

`TargetType::folder_name()` is a naive `"{}s"` pluralization of whatever type string was stored on the link. Every other endpoint-existence check in the codebase — `link::crud_helpers::entity_exists` (used by `CreateLink`) and `resolve_item_type_config` — instead resolves the type through `ItemTypeRegistry::resolve()`, which maps a type name to its *actual configured* storage folder (exact folder match, case-insensitive name match, case-insensitive folder match).

When an endpoint's stored type doesn't naively pluralize to its real folder (e.g. a custom type registered as folder `stories` with name `story` — `story` + `s` = `storys`, not `stories`), the sweep looks in the wrong (non-existent) directory, concludes the item is missing, and deletes the link — even though both endpoints are present on disk. This matches the issue's own diagnosis: only cross-type `relates-to` links were affected, while same-type `parent-of`/`blocks` links (whose naive pluralization happened to be correct) were untouched.

## Fix

`daemon/src/cleanup/project.rs`: `link_is_orphan` now resolves each endpoint's folder via `ItemTypeRegistry` (built once per sweep in `clean_orphan_links_for_project`, not per link), falling back to the naive `folder_name()` only when the registry has no match for that type — the same fallback strategy already used by `entity_exists`.

## Tests

Added `test_valid_cross_type_relates_to_link_survives_orphan_cleanup` in `daemon/src/cleanup/cleanup_tests.rs`: registers a second item type (`stories`, name `Story`) whose folder is an irregular plural, links a live issue to a live story via `relates-to`, runs the orphan sweep, and asserts the link survives.

- Confirmed this test **fails** on the old code (`left: 0, right: 1` — link wrongly pruned) before the fix.
- Confirmed it **passes** with the fix.
- Full suite: `cargo test --all-targets` — all targets green (814 tests in the binary target incl. the new one, 800 in the lib target, no failures).
- `cargo fmt --check` clean on changed files.
- `cargo clippy --all-targets` on changed files: no new warnings/errors (repo currently has ~11 pre-existing clippy errors on `main` unrelated to this change — confirmed present before my commit too; left out of scope for this issue).

Closes #295