### PR TITLE
fix(init): don't nest .centy inside an org's .centy repo

### DIFF
--- a/daemon/src/utils/mod.rs
+++ b/daemon/src/utils/mod.rs
@@ -15,9 +15,17 @@ pub const MANIFEST_FILE: &str = ".centy-manifest.json";
 /// Current centy version (from Cargo.toml)
 pub const CENTY_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-/// Get the path to the .centy folder
+/// Get the path to the .centy folder.
+///
+/// If `project_path` already *is* a `.centy` folder (its final component is
+/// literally `.centy` — the convention used for an org-wide `.centy` repo,
+/// see `registry::org_repo`), it is returned as-is instead of nesting a
+/// second `.centy` inside it.
 #[must_use]
 pub fn get_centy_path(project_path: &Path) -> std::path::PathBuf {
+    if project_path.file_name().is_some_and(|name| name == CENTY_FOLDER) {
+        return project_path.to_path_buf();
+    }
     project_path.join(CENTY_FOLDER)
 }
 

--- a/daemon/src/utils/path_utilities.rs
+++ b/daemon/src/utils/path_utilities.rs
@@ -53,6 +53,17 @@ fn test_now_iso_format() {
 }
 
 #[test]
+fn test_get_centy_path_already_dot_centy_returns_as_is() {
+    // Regression test for #282: an org-wide `.centy` repo (registry
+    // convention: project path ends in `/.centy`) must not get a second
+    // `.centy` nested inside it.
+    let project_path = Path::new("/home/user/my-org/.centy");
+    let centy_path = get_centy_path(project_path);
+
+    assert_eq!(centy_path, Path::new("/home/user/my-org/.centy"));
+}
+
+#[test]
 fn test_get_centy_path_relative() {
     let project_path = Path::new(".");
     let centy_path = get_centy_path(project_path);

--- a/daemon/tests/init_test.rs
+++ b/daemon/tests/init_test.rs
@@ -57,6 +57,36 @@ async fn test_init_creates_manifest_and_structure() {
 }
 
 #[tokio::test]
+async fn test_init_on_org_centy_repo_does_not_nest() {
+    // Regression test for #282: running init with a project_path that is
+    // itself already a `.centy` folder (the org-wide repo convention) must
+    // place managed files directly inside it, not under a nested
+    // `.centy/.centy`.
+    let temp_dir = create_test_dir();
+    let org_centy_path = temp_dir.path().join(".centy");
+    fs::create_dir_all(&org_centy_path)
+        .await
+        .expect("Should create org .centy dir");
+
+    init_centy_project(&org_centy_path).await;
+
+    // Managed files should land directly in org_centy_path, not in
+    // org_centy_path/.centy.
+    assert!(
+        org_centy_path.join(".centy-manifest.json").exists(),
+        "Manifest should be created directly in the org .centy repo"
+    );
+    assert!(
+        org_centy_path.join("issues").is_dir(),
+        "issues/ should be created directly in the org .centy repo"
+    );
+    assert!(
+        !org_centy_path.join(".centy").exists(),
+        "Should NOT create a nested .centy/.centy folder"
+    );
+}
+
+#[tokio::test]
 async fn test_init_idempotent() {
     let temp_dir = create_test_dir();
     let project_path = temp_dir.path();


### PR DESCRIPTION
## Summary

Running `centy init` from inside an org's `.centy` repo itself (cwd is
`<org>/.centy/`) created a nested `<org>/.centy/.centy` structure
instead of using the existing directory as-is.

Root cause: `get_centy_path()` in `daemon/src/utils/mod.rs`
unconditionally did `project_path.join(".centy")`. The org-wide
`.centy` repo is a real, first-class concept in this codebase — see
`daemon/src/registry/org_repo.rs`, which documents that "The org-wide
`.centy` repo is a tracked project whose path ends with `/.centy`" —
so `project_path` legitimately *is* a `.centy` folder in that case,
and appending another `.centy` produced the double nesting.

## Fix

`get_centy_path()` now checks whether `project_path`'s final component
is already `.centy` (via `Path::file_name`) and, if so, returns it
unchanged instead of appending another `.centy`. This is the single
shared function all ~40 call sites route through (config, items,
links, users, hooks, reconciliation, etc.), so the fix applies
uniformly without touching any caller. A normal project root is never
named `.centy`, so existing behavior for regular projects is
unaffected.

## Testing

- Added `test_get_centy_path_already_dot_centy_returns_as_is` unit
  test in `daemon/src/utils/path_utilities.rs`.
- Added `test_init_on_org_centy_repo_does_not_nest` integration test
  in `daemon/tests/init_test.rs`, which runs `execute_reconciliation`
  (the same path `centy init` uses) against a `project_path` ending in
  `.centy` and asserts managed files land directly in it with no
  nested `.centy/.centy`.
- `cargo test --all-targets`: 801+ tests pass, 0 failures.
- `cargo build --release`: succeeds.
- `cargo clippy --all-targets -- -D warnings`: fails, but with the
  *same* pre-existing errors already present on `main` (verified via
  `git stash` before pushing, and cross-checked against the `Build`
  workflow log on the latest `main` commit — https://github.com/centy-io/centy-daemon/actions/runs/28580129726
  — which is red for the identical `map_unwrap_or` /
  `non_ascii_literal` lints in unrelated files: `user/git.rs`,
  `workspace/standalone.rs`, `registry/organizations/slug_tests.rs`).
  This appears to be Rust/clippy toolchain drift unrelated to this
  change; none of the clippy output references any file touched by
  this PR.

Closes #282