### PR TITLE
chore: add missing changesets

### DIFF
--- a/.changeset/fix-organizations-unicode-slugify.md
+++ b/.changeset/fix-organizations-unicode-slugify.md
@@ -1,0 +1,5 @@
+---
+"@centy-io/centy-daemon": patch
+---
+
+Use the slug crate for unicode-safe slugify in organizations, fixing incorrect slug generation for non-ASCII names. (#294)


### PR DESCRIPTION
Adds a missing changeset for a merged PR that lacked one.

- PR #294 is now covered by `.changeset/fix-organizations-unicode-slugify.md`.

This PR was opened automatically by the moadim routine "Changesets keeper (owned repos + my orgs)".