### PR TITLE
chore: add missing changesets

### DIFF
--- a/.changeset/fix-cleanup-link-endpoint-resolution.md
+++ b/.changeset/fix-cleanup-link-endpoint-resolution.md
@@ -1,0 +1,5 @@
+---
+"@centy-io/centy-daemon": patch
+---
+
+Fixed the orphan-link cleanup sweep wrongly deleting valid cross-type `relates-to` links when a custom item type's folder name didn't naively pluralize to match (e.g. a `story` type stored in a `stories` folder). Endpoint existence is now resolved through the item type registry, consistent with link creation. (#296)

--- a/.changeset/fix-link-type-prefix.md
+++ b/.changeset/fix-link-type-prefix.md
@@ -1,0 +1,5 @@
+---
+"@centy-io/centy-daemon": patch
+---
+
+Fixed `centy link` ignoring the `type:` prefix on source/target arguments (e.g. `plan:1`, `issue:<uuid>`), which broke cross-type linking and could raise a false self-link error when two items of different types shared the same display number. (#285)

--- a/.changeset/fix-nested-centy-folder-on-init.md
+++ b/.changeset/fix-nested-centy-folder-on-init.md
@@ -1,0 +1,5 @@
+---
+"@centy-io/centy-daemon": patch
+---
+
+Fixed `centy init` creating a nested `.centy/.centy` folder when run from inside a directory that is already a `.centy` repo (e.g. an org's `.centy` repo). The existing directory is now reused instead of being duplicated. (#284)


### PR DESCRIPTION
Adds pending changeset files for three merged fixes that had none:

- #284 — fix: `centy init` no longer creates a nested `.centy/.centy` folder when run inside a directory that's already a `.centy` repo.
- #285 — fix(link): `centy link` now honors the `type:` prefix on source/target arguments, fixing cross-type linking and a false self-link error.
- #296 — fix(cleanup): orphan-link cleanup now resolves endpoint folders via the item type registry, so valid cross-type links with irregularly-pluralized folders survive the sweep.

No version bump or publish performed — this only adds the changeset entries.

---
Opened automatically by the **Changesets keeper (owned repos + my orgs)** moadim routine.