### PR TITLE
feat: launch Centy web app on localhost

### DIFF
--- a/.changeset/serve-web-localhost.md
+++ b/.changeset/serve-web-localhost.md
@@ -1,0 +1,5 @@
+---
+"@centy-io/centy-daemon": patch
+---
+
+Add an opt-in daemon command to launch the bundled Centy web app on localhost.

--- a/daemon/src/app.rs
+++ b/daemon/src/app.rs
@@ -18,6 +18,12 @@ pub struct Args {
         value_delimiter = ','
     )]
     pub cors_origins: Vec<String>,
+    /// Launch the bundled Centy web app on localhost.
+    #[arg(long, env = "CENTY_SERVE_WEB", default_value_t = false)]
+    pub serve_web: bool,
+    /// Address for the bundled Centy web app.
+    #[arg(long, env = "CENTY_WEB_ADDR", default_value = "127.0.0.1:5180")]
+    pub web_addr: String,
     /// Enable JSON log format (for production/log aggregation)
     #[arg(long, env = "CENTY_LOG_JSON", default_value = "false")]
     pub log_json: bool,

--- a/daemon/src/run/mod.rs
+++ b/daemon/src/run/mod.rs
@@ -20,6 +20,22 @@ pub async fn run(args: app::Args) -> Result<()> {
     crate::registry::init_ignore_paths(&user_cfg.registry.ignore_paths);
     let addr = args.addr.parse()?;
     let cors = core::build_cors(&args.cors_origins);
+    let web_process = if args.serve_web {
+        let (host, port) = args
+            .web_addr
+            .rsplit_once(':')
+            .ok_or_else(|| color_eyre::eyre::eyre!("CENTY_WEB_ADDR must be host:port"))?;
+        let child = std::process::Command::new("pnpm")
+            .args(["--dir", "web", "dev", "--hostname", host, "--port", port])
+            .spawn()
+            .map_err(|error| {
+                color_eyre::eyre::eyre!("failed to launch bundled web app: {error}")
+            })?;
+        info!(address = %args.web_addr, "Starting bundled Centy web app");
+        Some(child)
+    } else {
+        None
+    };
     let (tx_raw, mut shutdown_rx) = watch::channel(ShutdownSignal::None);
     let shutdown_tx = Arc::new(tx_raw);
     let exe_path = std::env::current_exe().ok();
@@ -66,6 +82,11 @@ pub async fn run(args: app::Args) -> Result<()> {
             }
         })
         .await;
+    if let Some(mut child) = web_process {
+        if let Err(error) = child.kill() {
+            warn!(%error, "Failed to stop bundled Centy web app");
+        }
+    }
     if let Err(e) = server_result {
         report_server_error(addr, &log_file, &e);
         return Err(e.into());


### PR DESCRIPTION
Adds --serve-web / CENTY_SERVE_WEB to launch the bundled web app on localhost:5180 alongside the daemon.