### PR TITLE
feat(daemon): expose built-in localhost MCP endpoint

### DIFF
--- a/.changeset/builtin-rmcp-localhost.md
+++ b/.changeset/builtin-rmcp-localhost.md
@@ -1,0 +1,5 @@
+---
+"centy-daemon": minor
+---
+
+Expose the daemon's built-in loopback-only Streamable HTTP MCP endpoint at `http://127.0.0.1:50052/mcp`, backed by rmcp and the existing gRPC API.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -127,7 +127,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -149,14 +149,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "bytes",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -167,6 +167,39 @@ dependencies = [
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core 0.5.6",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -190,6 +223,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +261,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bitflags"
@@ -255,6 +313,8 @@ version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum 0.8.9",
+ "bytes",
  "chrono",
  "clap",
  "color-eyre",
@@ -271,8 +331,10 @@ dependencies = [
  "mdstore",
  "once_cell",
  "prost",
+ "prost-reflect",
  "regex",
  "replace-homedir",
+ "rmcp",
  "semver",
  "serde",
  "serde_json",
@@ -307,6 +369,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -362,7 +435,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -420,6 +493,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,8 +532,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
 ]
 
 [[package]]
@@ -465,7 +557,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -474,9 +579,20 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core 0.24.1",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -500,10 +616,10 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -513,7 +629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -582,8 +698,14 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -721,7 +843,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -795,6 +917,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -805,7 +928,7 @@ checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1211,6 +1334,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1387,6 +1512,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "mdstore"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,6 +1678,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1574,6 +1714,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -1611,7 +1757,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1651,7 +1797,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1697,7 +1843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1735,7 +1881,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.118",
  "tempfile",
 ]
 
@@ -1749,7 +1895,21 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5edd582b62f5cde844716e66d92565d7faf7ab1445c8cebce6e00fba83ddb2"
+dependencies = [
+ "base64 0.22.1",
+ "once_cell",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde-value",
 ]
 
 [[package]]
@@ -1790,7 +1950,18 @@ checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1800,7 +1971,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1811,6 +1982,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -1841,6 +2018,26 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1879,6 +2076,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e03df677924bef3e03b5440480f862b0a622bca453159d86278c82bd43220b"
 dependencies = [
  "dirs 5.0.1",
+]
+
+[[package]]
+name = "rmcp"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
+dependencies = [
+ "async-trait",
+ "base64 0.23.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "indexmap 2.14.0",
+ "pastey",
+ "pin-project-lite",
+ "rand 0.10.2",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
+dependencies = [
+ "darling 0.24.1",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1935,6 +2177,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1961,6 +2229,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1977,7 +2255,18 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1991,6 +2280,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2009,6 +2309,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -2031,7 +2343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2109,6 +2421,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sse-stream"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2160,6 +2485,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2173,7 +2509,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2215,7 +2551,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2226,7 +2562,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2303,7 +2639,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2418,8 +2754,8 @@ checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
- "base64",
+ "axum 0.7.9",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",
@@ -2451,7 +2787,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2486,7 +2822,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5299dd20801ad736dccb4a5ea0da7376e59cd98f213bf1c3d478cf53f4834b58"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "http",
  "http-body",
@@ -2511,7 +2847,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -2530,8 +2866,10 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper",
+ "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2596,7 +2934,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2810,7 +3148,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -2874,7 +3212,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2885,7 +3223,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3155,7 +3493,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -3176,7 +3514,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3196,7 +3534,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -3230,7 +3568,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ centy-daemon --cors-origins=http://localhost:5180
 CENTY_DAEMON_ADDR=127.0.0.1:50052 centy-daemon
 ```
 
+### Built-in MCP endpoint
+
+Every installed daemon also starts a loopback-only MCP Streamable HTTP endpoint at `http://127.0.0.1:50052/mcp`. Configure an MCP client with that URL; no separate `centy-mcp` package is required. Use `--mcp-addr` or `CENTY_MCP_ADDR` to select a different **loopback** address.
+
 ### gRPC API
 
 The daemon supports both **native gRPC** (HTTP/2) and **gRPC-Web** (HTTP/1.1), making it compatible with:

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -108,6 +108,10 @@ which = "6"
 shell-escape = "0.1"
 slug = "0.1.6"
 json-patch = "4.1.0"
+rmcp = { version = "3.1.4", features = ["transport-streamable-http-server"] }
+axum = { version = "0.8", features = ["http1", "tokio"] }
+prost-reflect = { version = "0.14.7", features = ["serde"] }
+bytes = "1"
 
 
 [build-dependencies]

--- a/daemon/src/app.rs
+++ b/daemon/src/app.rs
@@ -1,6 +1,8 @@
 use clap::Parser;
 pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("centy_descriptor");
 pub const DEFAULT_ADDR: &str = "127.0.0.1:50051";
+/// Address for the built-in MCP Streamable HTTP endpoint.
+pub const DEFAULT_MCP_ADDR: &str = crate::mcp::DEFAULT_ADDR;
 /// Centy Daemon - Local-first issue and documentation tracker service
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -8,6 +10,9 @@ pub struct Args {
     /// Address to bind the server to
     #[arg(short, long, env = "CENTY_DAEMON_ADDR", default_value = DEFAULT_ADDR)]
     pub addr: String,
+    /// Address to bind the built-in MCP Streamable HTTP endpoint (always loopback-only)
+    #[arg(long, env = "CENTY_MCP_ADDR", default_value = DEFAULT_MCP_ADDR)]
+    pub mcp_addr: String,
     /// Comma-separated list of allowed CORS origins.
     /// Use "*" to allow all origins (not recommended for production).
     /// Example: --cors-origins=https://app.centy.io,http://localhost:5180

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -30,6 +30,7 @@ mod item;
 mod link;
 mod logging;
 mod manifest;
+mod mcp;
 mod metrics;
 mod reconciliation;
 mod registry;

--- a/daemon/src/mcp/catalog.rs
+++ b/daemon/src/mcp/catalog.rs
@@ -1,0 +1,75 @@
+use prost_reflect::{DescriptorPool, MethodDescriptor};
+use rmcp::model::{Tool, ToolAnnotations};
+use serde_json::{json, Map, Value};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+pub struct Catalog {
+    methods: BTreeMap<String, MethodDescriptor>,
+    tools: Vec<Tool>,
+}
+
+impl Catalog {
+    pub fn from_descriptor(descriptor: &[u8]) -> color_eyre::eyre::Result<Self> {
+        let pool = DescriptorPool::decode(descriptor)?;
+        let service = pool
+            .get_service_by_name("centy.v1.CentyDaemon")
+            .ok_or_else(|| color_eyre::eyre::eyre!("CentyDaemon descriptor is missing"))?;
+        let methods: BTreeMap<String, MethodDescriptor> = service
+            .methods()
+            .map(|method| (tool_name(&method), method))
+            .collect();
+        let tools = methods.values().map(tool_for).collect();
+        Ok(Self { methods, tools })
+    }
+
+    pub fn method(&self, name: &str) -> Option<&MethodDescriptor> {
+        self.methods.get(name)
+    }
+
+    pub fn tools(&self) -> Vec<Tool> {
+        self.tools.clone()
+    }
+}
+
+fn tool_for(method: &MethodDescriptor) -> Tool {
+    let name = tool_name(method);
+    let mut annotations = ToolAnnotations::default();
+    annotations.read_only_hint = Some(is_read_only(method.name()));
+    let mut tool = Tool::default();
+    tool.name = name.into();
+    tool.title = Some(method.name().to_owned());
+    tool.description = Some(
+        format!(
+            "{} RPC. Arguments use protobuf JSON mapping for {}.",
+            method.name(),
+            method.input().full_name()
+        )
+        .into(),
+    );
+    tool.input_schema = Arc::new(input_schema());
+    tool.annotations = Some(annotations);
+    tool
+}
+
+fn tool_name(method: &MethodDescriptor) -> String {
+    format!("centy_v1_CentyDaemon_{}", method.name())
+}
+
+fn is_read_only(name: &str) -> bool {
+    name.starts_with("Get")
+        || name.starts_with("List")
+        || name.starts_with("Is")
+        || name.starts_with("Search")
+}
+
+fn input_schema() -> Map<String, Value> {
+    json!({
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Use protobuf JSON field names and values for this RPC request."
+    })
+    .as_object()
+    .expect("JSON literal is an object")
+    .clone()
+}

--- a/daemon/src/mcp/catalog.rs
+++ b/daemon/src/mcp/catalog.rs
@@ -1,6 +1,6 @@
 use prost_reflect::{DescriptorPool, MethodDescriptor};
 use rmcp::model::{Tool, ToolAnnotations};
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -64,12 +64,16 @@ fn is_read_only(name: &str) -> bool {
 }
 
 fn input_schema() -> Map<String, Value> {
-    json!({
-        "type": "object",
-        "additionalProperties": true,
-        "description": "Use protobuf JSON field names and values for this RPC request."
-    })
-    .as_object()
-    .expect("JSON literal is an object")
-    .clone()
+    [
+        ("type".to_owned(), Value::String("object".to_owned())),
+        ("additionalProperties".to_owned(), Value::Bool(true)),
+        (
+            "description".to_owned(),
+            Value::String(
+                "Use protobuf JSON field names and values for this RPC request.".to_owned(),
+            ),
+        ),
+    ]
+    .into_iter()
+    .collect()
 }

--- a/daemon/src/mcp/grpc.rs
+++ b/daemon/src/mcp/grpc.rs
@@ -1,0 +1,92 @@
+use bytes::Buf;
+use color_eyre::eyre::{Result, WrapErr};
+use prost::Message;
+use prost_reflect::{DynamicMessage, MessageDescriptor};
+use std::net::{IpAddr, SocketAddr};
+use tonic::codec::{Codec, DecodeBuf, Decoder, EncodeBuf, Encoder};
+use tonic::transport::Endpoint;
+use tonic::Status;
+
+pub fn endpoint_for(addr: SocketAddr) -> String {
+    let host = match addr.ip() {
+        IpAddr::V4(ip) if ip.is_unspecified() => "127.0.0.1".to_owned(),
+        IpAddr::V6(ip) if ip.is_unspecified() => "[::1]".to_owned(),
+        IpAddr::V6(_) => format!("[{}]", addr.ip()),
+        IpAddr::V4(_) => addr.ip().to_string(),
+    };
+    format!("http://{host}:{}", addr.port())
+}
+
+pub async fn unary(
+    endpoint: &str,
+    path: http::uri::PathAndQuery,
+    request: DynamicMessage,
+    response: MessageDescriptor,
+) -> Result<DynamicMessage> {
+    let channel = Endpoint::from_shared(endpoint.to_owned())
+        .wrap_err("invalid daemon gRPC endpoint")?
+        .connect()
+        .await
+        .wrap_err("failed to connect to daemon gRPC endpoint")?;
+    tonic::client::Grpc::new(channel)
+        .unary(
+            tonic::Request::new(request),
+            path,
+            DynamicCodec { response },
+        )
+        .await
+        .map(tonic::Response::into_inner)
+        .map_err(color_eyre::Report::from)
+}
+
+#[derive(Clone)]
+struct DynamicCodec {
+    response: MessageDescriptor,
+}
+
+impl Codec for DynamicCodec {
+    type Encode = DynamicMessage;
+    type Decode = DynamicMessage;
+    type Encoder = DynamicEncoder;
+    type Decoder = DynamicDecoder;
+
+    fn encoder(&mut self) -> Self::Encoder {
+        DynamicEncoder
+    }
+
+    fn decoder(&mut self) -> Self::Decoder {
+        DynamicDecoder {
+            descriptor: self.response.clone(),
+        }
+    }
+}
+
+struct DynamicEncoder;
+
+impl Encoder for DynamicEncoder {
+    type Item = DynamicMessage;
+    type Error = Status;
+
+    fn encode(&mut self, item: Self::Item, dst: &mut EncodeBuf<'_>) -> Result<(), Self::Error> {
+        item.encode(dst)
+            .map_err(|error| Status::internal(error.to_string()))
+    }
+}
+
+struct DynamicDecoder {
+    descriptor: MessageDescriptor,
+}
+
+impl Decoder for DynamicDecoder {
+    type Item = DynamicMessage;
+    type Error = Status;
+
+    fn decode(&mut self, src: &mut DecodeBuf<'_>) -> Result<Option<Self::Item>, Self::Error> {
+        if !src.has_remaining() {
+            return Ok(None);
+        }
+        DynamicMessage::decode(self.descriptor.clone(), src)
+            .map(Some)
+            .map_err(|error| Status::internal(error.to_string()))
+    }
+}

--- a/daemon/src/mcp/grpc.rs
+++ b/daemon/src/mcp/grpc.rs
@@ -1,6 +1,6 @@
-use bytes::Buf;
-use color_eyre::eyre::{Result, WrapErr};
-use prost::Message;
+use bytes::Buf as _;
+use color_eyre::eyre::{Result, WrapErr as _};
+use prost::Message as _;
 use prost_reflect::{DynamicMessage, MessageDescriptor};
 use std::net::{IpAddr, SocketAddr};
 use tonic::codec::{Codec, DecodeBuf, Decoder, EncodeBuf, Encoder};

--- a/daemon/src/mcp/mod.rs
+++ b/daemon/src/mcp/mod.rs
@@ -10,11 +10,11 @@ use tokio::sync::watch;
 pub const DEFAULT_ADDR: &str = "127.0.0.1:50052";
 
 pub async fn spawn(
-    addr: &str,
+    bind_addr: &str,
     grpc_addr: SocketAddr,
     mut shutdown: watch::Receiver<ShutdownSignal>,
 ) -> Result<tokio::task::JoinHandle<Result<()>>> {
-    let addr: SocketAddr = addr.parse().wrap_err("invalid MCP bind address")?;
+    let addr: SocketAddr = bind_addr.parse().wrap_err("invalid MCP bind address")?;
     if !addr.ip().is_loopback() {
         bail!("MCP endpoint must bind to a loopback address, got {addr}");
     }

--- a/daemon/src/mcp/mod.rs
+++ b/daemon/src/mcp/mod.rs
@@ -3,7 +3,7 @@ mod grpc;
 mod server;
 
 use crate::server::ShutdownSignal;
-use color_eyre::eyre::{bail, Result, WrapErr};
+use color_eyre::eyre::{bail, Result, WrapErr as _};
 use std::net::SocketAddr;
 use tokio::sync::watch;
 

--- a/daemon/src/mcp/mod.rs
+++ b/daemon/src/mcp/mod.rs
@@ -1,0 +1,40 @@
+mod catalog;
+mod grpc;
+mod server;
+
+use crate::server::ShutdownSignal;
+use color_eyre::eyre::{bail, Result, WrapErr};
+use std::net::SocketAddr;
+use tokio::sync::watch;
+
+pub const DEFAULT_ADDR: &str = "127.0.0.1:50052";
+
+pub async fn spawn(
+    addr: &str,
+    grpc_addr: SocketAddr,
+    mut shutdown: watch::Receiver<ShutdownSignal>,
+) -> Result<tokio::task::JoinHandle<Result<()>>> {
+    let addr: SocketAddr = addr.parse().wrap_err("invalid MCP bind address")?;
+    if !addr.ip().is_loopback() {
+        bail!("MCP endpoint must bind to a loopback address, got {addr}");
+    }
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .wrap_err_with(|| format!("failed to bind MCP endpoint on {addr}"))?;
+    let service = server::McpServer::new(grpc::endpoint_for(grpc_addr))?;
+    let router = axum::Router::new().nest_service("/mcp", service.into_service());
+    Ok(tokio::spawn(async move {
+        axum::serve(listener, router)
+            .with_graceful_shutdown(async move {
+                loop {
+                    if shutdown.changed().await.is_err()
+                        || *shutdown.borrow() != ShutdownSignal::None
+                    {
+                        break;
+                    }
+                }
+            })
+            .await
+            .wrap_err("MCP HTTP server failed")
+    }))
+}

--- a/daemon/src/mcp/server.rs
+++ b/daemon/src/mcp/server.rs
@@ -2,8 +2,8 @@ use super::{catalog::Catalog, grpc};
 use color_eyre::eyre::Result;
 use prost_reflect::DynamicMessage;
 use rmcp::model::{
-    CallToolRequestParams, CallToolResponse, CallToolResult, ListToolsResult, ServerCapabilities,
-    ServerInfo,
+    CallToolRequestParams, CallToolResponse, CallToolResult, Implementation, ListToolsResult,
+    ServerCapabilities, ServerInfo,
 };
 use rmcp::transport::streamable_http_server::{
     session::local::LocalSessionManager, StreamableHttpServerConfig, StreamableHttpService,
@@ -47,9 +47,14 @@ impl Clone for McpServer {
 
 impl ServerHandler for McpServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build()).with_instructions(
-            "Centy's built-in local MCP server. Every CentyDaemon RPC is a tool.",
-        )
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new(
+                "centy-daemon",
+                env!("CARGO_PKG_VERSION"),
+            ))
+            .with_instructions(
+                "Centy's built-in local MCP server. Every CentyDaemon RPC is a tool.",
+            )
     }
 
     fn list_tools(

--- a/daemon/src/mcp/server.rs
+++ b/daemon/src/mcp/server.rs
@@ -30,7 +30,7 @@ impl McpServer {
     pub fn into_service(self) -> StreamableHttpService<Self, LocalSessionManager> {
         StreamableHttpService::new(
             move || Ok(self.clone()),
-            Default::default(),
+            Arc::default(),
             StreamableHttpServerConfig::default(),
         )
     }
@@ -57,71 +57,68 @@ impl ServerHandler for McpServer {
         _request: Option<rmcp::model::PaginatedRequestParams>,
         _context: rmcp::service::RequestContext<rmcp::RoleServer>,
     ) -> impl Future<Output = std::result::Result<ListToolsResult, ErrorData>> + Send + '_ {
-        let tools = self.catalog.tools();
-        async move {
-            let mut result = ListToolsResult::default();
-            result.tools = tools;
-            Ok(result)
-        }
+        std::future::ready(Ok(ListToolsResult {
+            tools: self.catalog.tools(),
+            ..Default::default()
+        }))
     }
 
-    fn call_tool(
+    async fn call_tool(
         &self,
         request: CallToolRequestParams,
         _context: rmcp::service::RequestContext<rmcp::RoleServer>,
-    ) -> impl Future<Output = std::result::Result<CallToolResponse, ErrorData>> + Send + '_ {
-        async move {
-            let result = match self.catalog.method(&request.name).cloned() {
-                Some(method) => {
-                    self.call(method, request.arguments.unwrap_or_default())
-                        .await
-                }
-                None => CallToolResult::structured_error(
-                    serde_json::json!({"error": "unknown Centy RPC tool"}),
-                ),
-            };
-            Ok(result.into())
-        }
+    ) -> std::result::Result<CallToolResponse, ErrorData> {
+        let result = match self.catalog.method(&request.name).cloned() {
+            Some(method) => {
+                call(
+                    &self.grpc_endpoint,
+                    method,
+                    request.arguments.unwrap_or_default(),
+                )
+                .await
+            }
+            None => CallToolResult::structured_error(
+                serde_json::json!({"error": "unknown Centy RPC tool"}),
+            ),
+        };
+        Ok(result.into())
     }
 }
 
-impl McpServer {
-    async fn call(
-        &self,
-        method: prost_reflect::MethodDescriptor,
-        arguments: serde_json::Map<String, Value>,
-    ) -> CallToolResult {
-        let json = Value::Object(arguments).to_string();
-        let mut deserializer = serde_json::Deserializer::from_str(&json);
-        let input = match DynamicMessage::deserialize(method.input(), &mut deserializer) {
-            Ok(value) => value,
-            Err(error) => {
-                return CallToolResult::structured_error(
-                    serde_json::json!({"error": error.to_string()}),
-                )
-            }
-        };
-        let path = format!("/{}/{}", method.parent_service().full_name(), method.name());
-        let response = match grpc::unary(
-            &self.grpc_endpoint,
-            path.parse().expect("valid gRPC path"),
-            input,
-            method.output(),
-        )
-        .await
-        {
-            Ok(response) => response,
-            Err(error) => {
-                return CallToolResult::structured_error(
-                    serde_json::json!({"error": error.to_string()}),
-                )
-            }
-        };
-        serde_json::to_value(response).map_or_else(
-            |error| {
-                CallToolResult::structured_error(serde_json::json!({"error": error.to_string()}))
-            },
-            CallToolResult::structured,
-        )
-    }
+async fn call(
+    grpc_endpoint: &str,
+    method: prost_reflect::MethodDescriptor,
+    arguments: serde_json::Map<String, Value>,
+) -> CallToolResult {
+    let json = Value::Object(arguments).to_string();
+    let mut deserializer = serde_json::Deserializer::from_str(&json);
+    let input = match DynamicMessage::deserialize(method.input(), &mut deserializer) {
+        Ok(value) => value,
+        Err(error) => {
+            return CallToolResult::structured_error(
+                serde_json::json!({"error": error.to_string()}),
+            )
+        }
+    };
+    let rpc_path = format!("/{}/{}", method.parent_service().full_name(), method.name());
+    let path: http::uri::PathAndQuery = match rpc_path.parse() {
+        Ok(value) => value,
+        Err(error) => {
+            return CallToolResult::structured_error(
+                serde_json::json!({"error": error.to_string()}),
+            );
+        }
+    };
+    let response = match grpc::unary(grpc_endpoint, path, input, method.output()).await {
+        Ok(response) => response,
+        Err(error) => {
+            return CallToolResult::structured_error(
+                serde_json::json!({"error": error.to_string()}),
+            )
+        }
+    };
+    serde_json::to_value(response).map_or_else(
+        |error| CallToolResult::structured_error(serde_json::json!({"error": error.to_string()})),
+        CallToolResult::structured,
+    )
 }

--- a/daemon/src/mcp/server.rs
+++ b/daemon/src/mcp/server.rs
@@ -1,0 +1,127 @@
+use super::{catalog::Catalog, grpc};
+use color_eyre::eyre::Result;
+use prost_reflect::DynamicMessage;
+use rmcp::model::{
+    CallToolRequestParams, CallToolResponse, CallToolResult, ListToolsResult, ServerCapabilities,
+    ServerInfo,
+};
+use rmcp::transport::streamable_http_server::{
+    session::local::LocalSessionManager, StreamableHttpServerConfig, StreamableHttpService,
+};
+use rmcp::ErrorData;
+use rmcp::ServerHandler;
+use serde_json::Value;
+use std::future::Future;
+use std::sync::Arc;
+
+pub struct McpServer {
+    catalog: Arc<Catalog>,
+    grpc_endpoint: String,
+}
+
+impl McpServer {
+    pub fn new(grpc_endpoint: String) -> Result<Self> {
+        Ok(Self {
+            catalog: Arc::new(Catalog::from_descriptor(crate::app::FILE_DESCRIPTOR_SET)?),
+            grpc_endpoint,
+        })
+    }
+
+    pub fn into_service(self) -> StreamableHttpService<Self, LocalSessionManager> {
+        StreamableHttpService::new(
+            move || Ok(self.clone()),
+            Default::default(),
+            StreamableHttpServerConfig::default(),
+        )
+    }
+}
+
+impl Clone for McpServer {
+    fn clone(&self) -> Self {
+        Self {
+            catalog: Arc::clone(&self.catalog),
+            grpc_endpoint: self.grpc_endpoint.clone(),
+        }
+    }
+}
+
+impl ServerHandler for McpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build()).with_instructions(
+            "Centy's built-in local MCP server. Every CentyDaemon RPC is a tool.",
+        )
+    }
+
+    fn list_tools(
+        &self,
+        _request: Option<rmcp::model::PaginatedRequestParams>,
+        _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> impl Future<Output = std::result::Result<ListToolsResult, ErrorData>> + Send + '_ {
+        let tools = self.catalog.tools();
+        async move {
+            let mut result = ListToolsResult::default();
+            result.tools = tools;
+            Ok(result)
+        }
+    }
+
+    fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> impl Future<Output = std::result::Result<CallToolResponse, ErrorData>> + Send + '_ {
+        async move {
+            let result = match self.catalog.method(&request.name).cloned() {
+                Some(method) => {
+                    self.call(method, request.arguments.unwrap_or_default())
+                        .await
+                }
+                None => CallToolResult::structured_error(
+                    serde_json::json!({"error": "unknown Centy RPC tool"}),
+                ),
+            };
+            Ok(result.into())
+        }
+    }
+}
+
+impl McpServer {
+    async fn call(
+        &self,
+        method: prost_reflect::MethodDescriptor,
+        arguments: serde_json::Map<String, Value>,
+    ) -> CallToolResult {
+        let json = Value::Object(arguments).to_string();
+        let mut deserializer = serde_json::Deserializer::from_str(&json);
+        let input = match DynamicMessage::deserialize(method.input(), &mut deserializer) {
+            Ok(value) => value,
+            Err(error) => {
+                return CallToolResult::structured_error(
+                    serde_json::json!({"error": error.to_string()}),
+                )
+            }
+        };
+        let path = format!("/{}/{}", method.parent_service().full_name(), method.name());
+        let response = match grpc::unary(
+            &self.grpc_endpoint,
+            path.parse().expect("valid gRPC path"),
+            input,
+            method.output(),
+        )
+        .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                return CallToolResult::structured_error(
+                    serde_json::json!({"error": error.to_string()}),
+                )
+            }
+        };
+        serde_json::to_value(response).map_or_else(
+            |error| {
+                CallToolResult::structured_error(serde_json::json!({"error": error.to_string()}))
+            },
+            CallToolResult::structured,
+        )
+    }
+}

--- a/daemon/src/registry/storage_tests.rs
+++ b/daemon/src/registry/storage_tests.rs
@@ -10,6 +10,7 @@ fn acquire_lock() -> std::sync::MutexGuard<'static, ()> {
 
 #[test]
 fn test_get_registry_path() {
+    let _lock = acquire_lock();
     // This test will work if HOME or USERPROFILE is set (or CENTY_HOME for isolated test runs)
     let result = get_registry_path();
     let home_set = std::env::var("HOME").is_ok()

--- a/daemon/src/run/mod.rs
+++ b/daemon/src/run/mod.rs
@@ -23,6 +23,7 @@ pub async fn run(args: app::Args) -> Result<()> {
     let web_process = core::launch_web(args.serve_web, &args.web_addr)?;
     let (tx_raw, mut shutdown_rx) = watch::channel(ShutdownSignal::None);
     let shutdown_tx = Arc::new(tx_raw);
+    let mcp_task = crate::mcp::spawn(&args.mcp_addr, addr, shutdown_tx.subscribe()).await?;
     let exe_path = std::env::current_exe().ok();
     crate::cleanup::spawn_cleanup_task();
     let service = CentyDaemonService::new(Arc::clone(&shutdown_tx), exe_path, user_cfg);
@@ -67,6 +68,7 @@ pub async fn run(args: app::Args) -> Result<()> {
             }
         })
         .await;
+    mcp_task.await.map_err(color_eyre::eyre::Report::from)??;
     core::stop_web(web_process);
     if let Err(e) = server_result {
         report_server_error(addr, &log_file, &e);


### PR DESCRIPTION
## Summary
- embeds a loopback-only rmcp Streamable HTTP endpoint at `http://127.0.0.1:50052/mcp`
- dynamically exposes all unary `CentyDaemon` RPCs from the checked-in descriptor and forwards calls to the existing local gRPC listener
- adds `--mcp-addr` / `CENTY_MCP_ADDR`, documentation, and a changeset

## Compatibility
- Uses a separate Axum 0.8 listener rather than mounting into tonic, avoiding the existing Axum 0.7 server stack.
- MCP binding is rejected unless it is a loopback address; the gRPC service remains unchanged.

## Verification
- `cargo check --manifest-path daemon/Cargo.toml`
