### PR TITLE
chore(release): prepare v0.15.0

### DIFF
--- a/.changeset/release-v0-15-0.md
+++ b/.changeset/release-v0-15-0.md
@@ -1,0 +1,5 @@
+---
+"centy-daemon": minor
+---
+
+Release v0.15.0 with the built-in Streamable HTTP MCP endpoint and without the obsolete external Go MCP publisher.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -440,55 +440,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # ============================================================================
-  # MCP: Build binaries and upload to release
-  # ============================================================================
-  build-mcp:
-    name: Build MCP binaries
-    needs: release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Install buf
-        uses: bufbuild/buf-action@v1
-        with:
-          setup_only: true
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: stable
-          cache-dependency-path: mcp/go.sum
-
-      - name: Generate
-        run: make -C mcp generate
-
-      - name: Build binaries
-        run: |
-          VERSION="${{ github.ref_name }}"
-          VERSION="${VERSION#v}"
-          cd mcp
-          GOOS=linux   GOARCH=amd64 go build -ldflags "-X main.version=${VERSION}" -o ../centy-mcp-linux-x86_64   .
-          GOOS=linux   GOARCH=arm64 go build -ldflags "-X main.version=${VERSION}" -o ../centy-mcp-linux-aarch64  .
-          GOOS=darwin  GOARCH=amd64 go build -ldflags "-X main.version=${VERSION}" -o ../centy-mcp-darwin-x86_64  .
-          GOOS=darwin  GOARCH=arm64 go build -ldflags "-X main.version=${VERSION}" -o ../centy-mcp-darwin-aarch64 .
-          GOOS=windows GOARCH=amd64 go build -ldflags "-X main.version=${VERSION}" -o ../centy-mcp-windows-x86_64.exe .
-
-      - name: Upload to release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            centy-mcp-linux-x86_64
-            centy-mcp-linux-aarch64
-            centy-mcp-darwin-x86_64
-            centy-mcp-darwin-aarch64
-            centy-mcp-windows-x86_64.exe
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # ============================================================================
   # CLI: Build binaries and upload to release
   # ============================================================================
   build-cli:

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "centy-daemon"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "A file-based database engine that stores structured data as Markdown files with YAML frontmatter, exposed via gRPC"
 authors = ["Centy Team"]


### PR DESCRIPTION
Removes the obsolete Go MCP binary/npm publishing jobs from the release workflow and bumps the daemon package version to 0.15.0.